### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published, edited]
 
+permissions:
+  contents: write
+
 jobs:
   update_version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Snuffy2/openvpn_otp_auth/security/code-scanning/6](https://github.com/Snuffy2/openvpn_otp_auth/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow (or to the specific job, if you want fine-grained control). At a minimum, since the workflow pushes commits and tags, it requires `contents: write` permissions for pushing code (and tags). If the workflow ever needs to update or interact with pull requests, it should include the relevant permission, but in this workflow only `contents` access is necessary. The best practice is to add:

```yaml
permissions:
  contents: write
```

at the root level (applies to all jobs by default), or inside the `update_version` job (for job-level specificity). As the workflow only contains one job, adding it at the root is simplest and matches the recommended pattern unless future jobs might have differing needs.

**Required changes:**
- Insert the block:
  ```yaml
  permissions:
    contents: write
  ```
  After the workflow name and event triggers but before the `jobs:` block (top-level).
- No new imports, methods, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
