### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,4 +1,6 @@
 name: Linters
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Snuffy2/openvpn_otp_auth/security/code-scanning/5](https://github.com/Snuffy2/openvpn_otp_auth/security/code-scanning/5)

To fix this issue, an explicit `permissions` field should be added to the workflow to restrict the GITHUB_TOKEN permissions following the principle of least privilege. Since the job only needs to check out code and run tools, but does not need to push changes or interact with pull requests or issues, `contents: read` is sufficient. The explicit addition of the `permissions:` block at the workflow root (top-level) makes the intention clear and will apply to all jobs in the workflow unless overridden.

**How to fix:**  
Insert the following block after the `name:` field at the top of `.github/workflows/linters.yml`:

```yaml
permissions:
  contents: read
```

**Where to change:**  
- File: `.github/workflows/linters.yml`
- Region: After line 1 (`name: Linters`) and before `on:`

No imports, methods or additional definitions are required for this YAML change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration linters workflow permissions to use read-only access for repository contents.
  * Maintenance-only change to the build pipeline; no impact on features, performance, or user interface.
  * Linters continue to run as before; triggers and checks remain unchanged.
  * Improves operational governance and stability. No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->