### PR TITLE
Harden OpenVPN OTP auth file handling

### DIFF
--- a/openvpn_otp_auth.py
+++ b/openvpn_otp_auth.py
@@ -390,12 +390,14 @@ class OpenVPNOTPAuth:
         """
         logger.info("Rehashing password for user: %s", username)
         userdb, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "UPDATE users SET password_hash = ? WHERE username = ?",
-            (new_hash, username),
-        )
-        userdb.commit()
-        userdb.close()
+        try:
+            usercursor.execute(
+                "UPDATE users SET password_hash = ? WHERE username = ?",
+                (new_hash, username),
+            )
+            userdb.commit()
+        finally:
+            userdb.close()
 
     def verify_totp(self, secret: str, otp: str) -> bool:
         """Verify a TOTP code against the user's secret.
@@ -442,13 +444,15 @@ class OpenVPNOTPAuth:
 
         """
         sessiondb, sessioncursor = self.get_sessiondb_cursor()
-        sessioncursor.execute(
-            "REPLACE INTO sessions (username, vpn_client, ip_address, verified_on) "
-            "VALUES (?,?,?,?)",
-            (username, vpn_client, current_ip, created),
-        )
-        sessiondb.commit()
-        sessiondb.close()
+        try:
+            sessioncursor.execute(
+                "REPLACE INTO sessions (username, vpn_client, ip_address, verified_on) "
+                "VALUES (?,?,?,?)",
+                (username, vpn_client, current_ip, created),
+            )
+            sessiondb.commit()
+        finally:
+            sessiondb.close()
 
     def get_session(self, username: str) -> tuple | None:
         """Retrieve session information for a given username from the session database.
@@ -694,12 +698,15 @@ class OpenVPNOTPAuth:
             name=new_user, issuer_name=self.issuer
         )
         userdb, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "INSERT INTO users (username, password_hash, totp_secret, totp_uri) VALUES (?,?,?,?)",
-            (new_user, self.ph.hash(new_pass), totp_secret, totp_uri),
-        )
-        userdb.commit()
-        userdb.close()
+        try:
+            usercursor.execute(
+                "INSERT INTO users (username, password_hash, totp_secret, totp_uri) "
+                "VALUES (?,?,?,?)",
+                (new_user, self.ph.hash(new_pass), totp_secret, totp_uri),
+            )
+            userdb.commit()
+        finally:
+            userdb.close()
         if self.check_user(new_user):
             setup_logger.info("User Added: %s", new_user)
             self._write_totp_file(new_user, totp_uri)
@@ -733,12 +740,14 @@ class OpenVPNOTPAuth:
             with contextlib.suppress(FileNotFoundError):
                 f.unlink()
         userdb, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "DELETE FROM users WHERE username=?",
-            (del_user,),
-        )
-        userdb.commit()
-        userdb.close()
+        try:
+            usercursor.execute(
+                "DELETE FROM users WHERE username=?",
+                (del_user,),
+            )
+            userdb.commit()
+        finally:
+            userdb.close()
         if self.check_user(del_user):
             setup_logger.error("Delete Failed: %s", del_user)
         else:
@@ -767,12 +776,14 @@ class OpenVPNOTPAuth:
             setup_logger.error("Passwords don't match. Password not changed for: %s", user)
             sys.exit(99)
         userdb, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "UPDATE users SET password_hash = ? WHERE username = ?",
-            (self.ph.hash(new_pass), user),
-        )
-        userdb.commit()
-        userdb.close()
+        try:
+            usercursor.execute(
+                "UPDATE users SET password_hash = ? WHERE username = ?",
+                (self.ph.hash(new_pass), user),
+            )
+            userdb.commit()
+        finally:
+            userdb.close()
         setup_logger.info("Password Updated: %s", user)
         sys.exit(99)
 
@@ -800,12 +811,14 @@ class OpenVPNOTPAuth:
         totp_secret = pyotp.random_base32()
         totp_uri = pyotp.totp.TOTP(totp_secret).provisioning_uri(name=user, issuer_name=self.issuer)
         userdb, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "UPDATE users SET totp_secret = ?, totp_uri = ? WHERE username = ?",
-            (totp_secret, totp_uri, user),
-        )
-        userdb.commit()
-        userdb.close()
+        try:
+            usercursor.execute(
+                "UPDATE users SET totp_secret = ?, totp_uri = ? WHERE username = ?",
+                (totp_secret, totp_uri, user),
+            )
+            userdb.commit()
+        finally:
+            userdb.close()
         setup_logger.info("TOTP Updated: %s", user)
         if totp_file is None:
             setup_logger.info(totp_uri)

--- a/openvpn_otp_auth.py
+++ b/openvpn_otp_auth.py
@@ -45,6 +45,7 @@ file_formatter = logging.Formatter(
     "%(asctime)s %(levelname)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
 )
 log_file_path = Path(__file__).resolve().parent / "openvpn_otp_auth.log"
+file_handler: logging.FileHandler | None = None
 try:
     file_handler = logging.FileHandler(log_file_path)
     file_handler.setLevel(logging.INFO)
@@ -145,7 +146,8 @@ args = parser.parse_args()
 if args.debug:
     logger.setLevel(logging.DEBUG)
     stdout_handler.setLevel(logging.DEBUG)
-    file_handler.setLevel(logging.DEBUG)
+    if file_handler is not None:
+        file_handler.setLevel(logging.DEBUG)
     setup_logger.setLevel(logging.DEBUG)
     setup_stdout_handler.setLevel(logging.DEBUG)
 
@@ -178,6 +180,44 @@ class OpenVPNOTPAuth:
     def _strip_quotes(self, value: str) -> str:
         """Remove surrounding quotes from config values."""
         return value.strip('"').strip("'")
+
+    def _totp_file_path(self, username: str) -> Path:
+        """Build the TOTP file path for a username without allowing path traversal."""
+        if (
+            username in {"", ".", ".."}
+            or "/" in username
+            or "\\" in username
+            or Path(username).is_absolute()
+        ):
+            raise ValueError(f"Unsafe username for TOTP file path: {username}")
+        return Path(self.totp_out_path) / f"{username}.totp"
+
+    def _write_totp_file(self, username: str, totp_uri: str) -> Path:
+        """Write a user's TOTP QR output and URI to the configured output path."""
+        totp_file = self._totp_file_path(username)
+        try:
+            subprocess.run(
+                [
+                    "qrencode",
+                    totp_uri,
+                    "-t",
+                    "UTF8",
+                    "-o",
+                    f"{totp_file}",
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            setup_logger.warning(
+                "Failed to generate QR code: %s. Make sure qrencode is installed.", e
+            )
+            totp_file.write_text(totp_uri)
+        else:
+            with totp_file.open("a") as f:
+                f.write(f"\n{totp_uri}")
+        return totp_file
 
     def load_config(self) -> None:
         """Load configuration settings from the config file.
@@ -303,12 +343,15 @@ class OpenVPNOTPAuth:
             user exists, otherwise None.
 
         """
-        _, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "SELECT username, password_hash, totp_secret, totp_uri FROM users WHERE username=?",
-            (username,),
-        )
-        return usercursor.fetchone()
+        userdb, usercursor = self.get_userdb_cursor()
+        try:
+            usercursor.execute(
+                "SELECT username, password_hash, totp_secret, totp_uri FROM users WHERE username=?",
+                (username,),
+            )
+            return usercursor.fetchone()
+        finally:
+            userdb.close()
 
     def check_user(self, username: str) -> bool:
         """Check if a user exists in the database.
@@ -324,12 +367,15 @@ class OpenVPNOTPAuth:
             True if the user exists, False otherwise.
 
         """
-        _, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "SELECT username FROM users WHERE username=?",
-            (username,),
-        )
-        return usercursor.fetchone() is not None
+        userdb, usercursor = self.get_userdb_cursor()
+        try:
+            usercursor.execute(
+                "SELECT username FROM users WHERE username=?",
+                (username,),
+            )
+            return usercursor.fetchone() is not None
+        finally:
+            userdb.close()
 
     def update_hash_for_user(self, username: str, new_hash: str) -> None:
         """Update the password hash for a user in the database.
@@ -349,6 +395,7 @@ class OpenVPNOTPAuth:
             (new_hash, username),
         )
         userdb.commit()
+        userdb.close()
 
     def verify_totp(self, secret: str, otp: str) -> bool:
         """Verify a TOTP code against the user's secret.
@@ -401,6 +448,7 @@ class OpenVPNOTPAuth:
             (username, vpn_client, current_ip, created),
         )
         sessiondb.commit()
+        sessiondb.close()
 
     def get_session(self, username: str) -> tuple | None:
         """Retrieve session information for a given username from the session database.
@@ -417,12 +465,15 @@ class OpenVPNOTPAuth:
             exists, otherwise None.
 
         """
-        _, sessioncursor = self.get_sessiondb_cursor()
-        sessioncursor.execute(
-            "SELECT vpn_client, ip_address, verified_on FROM sessions WHERE username=?",
-            (username,),
-        )
-        return sessioncursor.fetchone()
+        sessiondb, sessioncursor = self.get_sessiondb_cursor()
+        try:
+            sessioncursor.execute(
+                "SELECT vpn_client, ip_address, verified_on FROM sessions WHERE username=?",
+                (username,),
+            )
+            return sessioncursor.fetchone()
+        finally:
+            sessiondb.close()
 
     def main(self) -> None:
         """Execute main authentication logic for OpenVPN OTP Auth.
@@ -444,7 +495,7 @@ class OpenVPNOTPAuth:
             pwd.getpwuid(os.geteuid()).pw_name,
             os.geteuid(),
         )
-        with Path(sys.argv[1]).open() as tmpfile:
+        with Path(self.args.filename).open() as tmpfile:
             username = tmpfile.readline().rstrip("\n")
             password = tmpfile.readline().rstrip("\n")
 
@@ -625,6 +676,11 @@ class OpenVPNOTPAuth:
 
         """
         new_user = self.args.adduser[0]
+        try:
+            totp_file = self._totp_file_path(new_user)
+        except ValueError as e:
+            setup_logger.error("%s", e)
+            sys.exit(99)
         if self.check_user(new_user):
             setup_logger.error("User Already Exists: %s", new_user)
             sys.exit(99)
@@ -643,30 +699,11 @@ class OpenVPNOTPAuth:
             (new_user, self.ph.hash(new_pass), totp_secret, totp_uri),
         )
         userdb.commit()
+        userdb.close()
         if self.check_user(new_user):
             setup_logger.info("User Added: %s", new_user)
-            try:
-                subprocess.run(
-                    [
-                        "qrencode",
-                        totp_uri,
-                        "-t",
-                        "UTF8",
-                        "-o",
-                        f"{self.totp_out_path}/{new_user}.totp",
-                    ],
-                    check=True,
-                    text=True,
-                    capture_output=True,
-                )
-            except (subprocess.CalledProcessError, FileNotFoundError) as e:
-                setup_logger.warning(
-                    "Failed to generate QR code: %s. Make sure qrencode is installed.", e
-                )
-                # Continue without QR code generation
-            with Path(f"{self.totp_out_path}/{new_user}.totp").open("a") as f:
-                f.write(f"{totp_uri}")
-            with Path(f"{self.totp_out_path}/{new_user}.totp").open() as f:
+            self._write_totp_file(new_user, totp_uri)
+            with totp_file.open() as f:
                 setup_logger.info(f.read())
         else:
             setup_logger.error("Add Failed: %s", new_user)
@@ -688,7 +725,11 @@ class OpenVPNOTPAuth:
         if not self.check_user(del_user):
             setup_logger.error("User Doesn't Exist: %s", del_user)
             sys.exit(99)
-        f = Path(f"{self.totp_out_path}/{del_user}.totp")
+        try:
+            f = self._totp_file_path(del_user)
+        except ValueError as e:
+            setup_logger.error("%s", e)
+            sys.exit(99)
         with contextlib.suppress(FileNotFoundError):
             f.unlink()
         userdb, usercursor = self.get_userdb_cursor()
@@ -697,6 +738,7 @@ class OpenVPNOTPAuth:
             (del_user,),
         )
         userdb.commit()
+        userdb.close()
         if self.check_user(del_user):
             setup_logger.error("Delete Failed: %s", del_user)
         else:
@@ -730,6 +772,7 @@ class OpenVPNOTPAuth:
             (self.ph.hash(new_pass), user),
         )
         userdb.commit()
+        userdb.close()
         setup_logger.info("Password Updated: %s", user)
         sys.exit(99)
 
@@ -746,6 +789,11 @@ class OpenVPNOTPAuth:
 
         """
         user = self.args.changetotp[0]
+        try:
+            totp_file = self._totp_file_path(user)
+        except ValueError as e:
+            setup_logger.error("%s", e)
+            sys.exit(99)
         if not self.check_user(user):
             setup_logger.error("User Doesn't Exist: %s", user)
             sys.exit(99)
@@ -757,22 +805,10 @@ class OpenVPNOTPAuth:
             (totp_secret, totp_uri, user),
         )
         userdb.commit()
+        userdb.close()
         setup_logger.info("TOTP Updated: %s", user)
-        try:
-            subprocess.run(
-                ["qrencode", totp_uri, "-t", "UTF8", "-o", f"{self.totp_out_path}/{user}.totp"],
-                check=True,
-                text=True,
-                capture_output=True,
-            )
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            setup_logger.warning(
-                "Failed to generate QR code: %s. Make sure qrencode is installed.", e
-            )
-            # Continue without QR code generation
-        with Path(f"{self.totp_out_path}/{user}.totp").open("a") as f:
-            f.write(f"{totp_uri}")
-        with Path(f"{self.totp_out_path}/{user}.totp").open() as f:
+        self._write_totp_file(user, totp_uri)
+        with totp_file.open() as f:
             setup_logger.info(f.read())
         sys.exit(99)
 
@@ -792,8 +828,10 @@ class OpenVPNOTPAuth:
             setup_logger.error("User Doesn't Exist: %s", user)
             sys.exit(99)
         try:
-            with Path(f"{self.totp_out_path}/{user}.totp").open() as f:
+            with self._totp_file_path(user).open() as f:
                 setup_logger.info(f.read())
+        except ValueError as e:
+            setup_logger.error("%s", e)
         except FileNotFoundError:
             setup_logger.error("TOTP file not found for user: %s", user)
         sys.exit(99)
@@ -814,11 +852,14 @@ class OpenVPNOTPAuth:
             Exits with code 99 after listing users.
 
         """
-        _, usercursor = self.get_userdb_cursor()
-        usercursor.execute(
-            "SELECT username FROM users ORDER BY username ASC",
-        )
-        users = usercursor.fetchall()
+        userdb, usercursor = self.get_userdb_cursor()
+        try:
+            usercursor.execute(
+                "SELECT username FROM users ORDER BY username ASC",
+            )
+            users = usercursor.fetchall()
+        finally:
+            userdb.close()
         setup_logger.info("Users: %d\n_______________________", len(users))
         for user in users:
             setup_logger.info("%s", user[0])

--- a/openvpn_otp_auth.py
+++ b/openvpn_otp_auth.py
@@ -728,10 +728,10 @@ class OpenVPNOTPAuth:
         try:
             f = self._totp_file_path(del_user)
         except ValueError as e:
-            setup_logger.error("%s", e)
-            sys.exit(99)
-        with contextlib.suppress(FileNotFoundError):
-            f.unlink()
+            setup_logger.warning("%s. Skipping TOTP file deletion.", e)
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                f.unlink()
         userdb, usercursor = self.get_userdb_cursor()
         usercursor.execute(
             "DELETE FROM users WHERE username=?",

--- a/openvpn_otp_auth.py
+++ b/openvpn_otp_auth.py
@@ -789,14 +789,14 @@ class OpenVPNOTPAuth:
 
         """
         user = self.args.changetotp[0]
-        try:
-            totp_file = self._totp_file_path(user)
-        except ValueError as e:
-            setup_logger.error("%s", e)
-            sys.exit(99)
         if not self.check_user(user):
             setup_logger.error("User Doesn't Exist: %s", user)
             sys.exit(99)
+        try:
+            totp_file = self._totp_file_path(user)
+        except ValueError as e:
+            setup_logger.warning("%s. Skipping TOTP file update.", e)
+            totp_file = None
         totp_secret = pyotp.random_base32()
         totp_uri = pyotp.totp.TOTP(totp_secret).provisioning_uri(name=user, issuer_name=self.issuer)
         userdb, usercursor = self.get_userdb_cursor()
@@ -807,9 +807,12 @@ class OpenVPNOTPAuth:
         userdb.commit()
         userdb.close()
         setup_logger.info("TOTP Updated: %s", user)
-        self._write_totp_file(user, totp_uri)
-        with totp_file.open() as f:
-            setup_logger.info(f.read())
+        if totp_file is None:
+            setup_logger.info(totp_uri)
+        else:
+            self._write_totp_file(user, totp_uri)
+            with totp_file.open() as f:
+                setup_logger.info(f.read())
         sys.exit(99)
 
     def showtotp(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,9 @@ force-sort-within-sections = true
 combine-as-imports = true
 split-on-trailing-comma = false
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]
+
 [tool.ruff.lint.mccabe]
 max-complexity = 25
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for openvpn_otp_auth."""

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -134,3 +134,40 @@ def test_deluser_removes_legacy_path_traversal_username_without_unlinking_outsid
             is None
         )
     assert outside_file.read_text() == "do not delete"
+
+
+def test_changetotp_updates_legacy_path_traversal_username_without_writing_outside_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Legacy unsafe usernames should get new TOTP secrets without unsafe file writes."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    auth = module.OpenVPNOTPAuth(argparse.Namespace(changetotp=["../outside"]), install=True)
+    auth.issuer = "Test VPN"
+    auth.totp_out_path = str(tmp_path)
+    auth.user_db_file = str(tmp_path / "users.db")
+    auth.session_db_file = str(tmp_path / "sessions.db")
+    outside_file = tmp_path.parent / "outside.totp"
+    outside_file.write_text("do not overwrite")
+    userdb, usercursor = auth.get_userdb_cursor()
+    usercursor.execute(
+        "INSERT INTO users (username, password_hash, totp_secret, totp_uri) VALUES (?,?,?,?)",
+        ("../outside", "hash", "old-secret", "old-uri"),
+    )
+    userdb.commit()
+    userdb.close()
+    monkeypatch.setattr(module.pyotp, "random_base32", lambda: "JBSWY3DPEHPK3PXP")
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth.changetotp()
+
+    assert exc_info.value.code == 99
+    stdout = capsys.readouterr().out
+    with sqlite3.connect(auth.user_db_file) as db:
+        totp_secret, totp_uri = db.execute(
+            "SELECT totp_secret, totp_uri FROM users WHERE username = ?",
+            ("../outside",),
+        ).fetchone()
+    assert totp_secret in totp_uri
+    assert totp_uri != "old-uri"
+    assert outside_file.read_text() == "do not overwrite"
+    assert totp_uri in stdout

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -102,16 +102,35 @@ def test_changetotp_rewrites_existing_totp_file_when_qr_generation_fails(
     assert "OLD QR CONTENT" not in totp_file.read_text()
 
 
-def test_deluser_rejects_path_traversal_username(
+def test_deluser_removes_legacy_path_traversal_username_without_unlinking_outside_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Usernames must not escape the configured TOTP output directory."""
+    """Legacy unsafe usernames should be removed without unsafe file deletion."""
     module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
     auth = module.OpenVPNOTPAuth(argparse.Namespace(deluser=["../outside"]), install=True)
     auth.totp_out_path = str(tmp_path)
-    monkeypatch.setattr(auth, "check_user", lambda _username: True)
+    auth.user_db_file = str(tmp_path / "users.db")
+    auth.session_db_file = str(tmp_path / "sessions.db")
+    outside_file = tmp_path.parent / "outside.totp"
+    outside_file.write_text("do not delete")
+    userdb, usercursor = auth.get_userdb_cursor()
+    usercursor.execute(
+        "INSERT INTO users (username, password_hash, totp_secret, totp_uri) VALUES (?,?,?,?)",
+        ("../outside", "hash", "secret", "uri"),
+    )
+    userdb.commit()
+    userdb.close()
 
     with pytest.raises(SystemExit) as exc_info:
         auth.deluser()
 
     assert exc_info.value.code == 99
+    with sqlite3.connect(auth.user_db_file) as db:
+        assert (
+            db.execute(
+                "SELECT username FROM users WHERE username = ?",
+                ("../outside",),
+            ).fetchone()
+            is None
+        )
+    assert outside_file.read_text() == "do not delete"

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -1,0 +1,117 @@
+"""Regression tests for the OpenVPN OTP auth script."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import logging
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "openvpn_otp_auth.py"
+
+
+def load_module(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> ModuleType:
+    """Load the script module with a controlled command-line argument list."""
+    module_name = "openvpn_otp_auth_under_test"
+    monkeypatch.setattr(sys, "argv", argv)
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module spec for {SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_debug_import_handles_unavailable_log_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Debug startup should not crash when the file logger cannot be created."""
+
+    def blocked_file_handler(*_args: Any, **_kwargs: Any) -> logging.FileHandler:
+        """Raise the same error a protected installation directory would raise."""
+        raise PermissionError("blocked")
+
+    monkeypatch.setattr(logging, "FileHandler", blocked_file_handler)
+
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--debug", "credentials"])
+
+    assert module.args.debug is True
+
+
+def test_main_uses_parsed_filename_when_debug_precedes_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The auth path should come from argparse, not the raw first argv item."""
+    credentials = tmp_path / "credentials.txt"
+    credentials.write_text("alice\nnot-scrv1\n")
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--debug", str(credentials)])
+    auth = module.OpenVPNOTPAuth(module.args, install=True)
+    monkeypatch.setattr(auth, "get_user", lambda _username: ("alice", "hash", "secret", "uri"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth.main()
+
+    assert exc_info.value.code == 1
+
+
+def test_changetotp_rewrites_existing_totp_file_when_qr_generation_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """TOTP rotation should not leave stale QR/file contents behind."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    args = argparse.Namespace(changetotp=["alice"])
+    auth = module.OpenVPNOTPAuth(args, install=True)
+    auth.issuer = "Test VPN"
+    auth.totp_out_path = str(tmp_path)
+    auth.user_db_file = str(tmp_path / "users.db")
+    auth.session_db_file = str(tmp_path / "sessions.db")
+    userdb, usercursor = auth.get_userdb_cursor()
+    usercursor.execute(
+        "INSERT INTO users (username, password_hash, totp_secret, totp_uri) VALUES (?,?,?,?)",
+        ("alice", "hash", "old-secret", "old-uri"),
+    )
+    userdb.commit()
+    userdb.close()
+    totp_file = tmp_path / "alice.totp"
+    totp_file.write_text("OLD QR CONTENT\nold-uri")
+    monkeypatch.setattr(module.pyotp, "random_base32", lambda: "JBSWY3DPEHPK3PXP")
+
+    def missing_qrencode(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Simulate a host that does not have qrencode installed."""
+        raise FileNotFoundError("qrencode")
+
+    monkeypatch.setattr(module.subprocess, "run", missing_qrencode)
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth.changetotp()
+
+    assert exc_info.value.code == 99
+    with sqlite3.connect(auth.user_db_file) as db:
+        totp_uri = db.execute(
+            "SELECT totp_uri FROM users WHERE username = ?",
+            ("alice",),
+        ).fetchone()[0]
+    assert totp_file.read_text() == totp_uri
+    assert "OLD QR CONTENT" not in totp_file.read_text()
+
+
+def test_deluser_rejects_path_traversal_username(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Usernames must not escape the configured TOTP output directory."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    auth = module.OpenVPNOTPAuth(argparse.Namespace(deluser=["../outside"]), install=True)
+    auth.totp_out_path = str(tmp_path)
+    monkeypatch.setattr(auth, "check_user", lambda _username: True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth.deluser()
+
+    assert exc_info.value.code == 99


### PR DESCRIPTION
## Summary

Hardens the OpenVPN auth helper around credential-file parsing, TOTP output generation, and SQLite connection lifecycle. Adds focused regression coverage for the failure modes fixed in the script.

## What Changed

- Uses the argparse-parsed credential filename during OpenVPN auth so flags such as `--debug` do not shift positional file handling.
- Allows debug startup to continue when the optional log file handler cannot be created.
- Centralizes TOTP output path construction and rejects usernames that could escape the configured output directory.
- Rewrites TOTP output deterministically when QR generation is unavailable or fails, keeping user creation and rotation usable without `qrencode`.
- Closes short-lived SQLite connections after user, session, and management operations.
- Adds pytest regression coverage for debug import behavior, parsed auth filenames, TOTP rewrite behavior, and traversal rejection.

## Why

The helper is used directly by OpenVPN and by CLI management commands, so small path or startup assumptions can become authentication failures or unsafe file writes. These changes keep the standalone script behavior intact while making the sensitive file and database paths more predictable.

## Validation

- `./.venv/bin/pytest`
- `./.venv/bin/mypy .`
- `./.venv/bin/prek run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resource cleanup by properly closing database connections across authentication methods.
  * Enhanced security for TOTP file handling with validation to prevent path traversal attacks.
  * Fixed credential file handling to use command-line arguments consistently.

* **Tests**
  * Added comprehensive regression tests covering authentication startup, credential file parsing, TOTP file regeneration, and username validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snuffy2/openvpn_otp_auth/pull/18)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->