### PR TITLE
Add pytest coverage workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,15 +18,18 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Setup python
-        id: setup_python
+      - name: Setup Python 3 (with caching)
         uses: actions/setup-python@v6
         with:
           python-version: '3.14'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
 
-      - name: Install requirements
-        run: pip install --group dev -e .
+      - name: Install linting requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install --group lint -e .
 
       - name: Run mypy
         run: mypy "." --install-types --non-interactive --config-file pyproject.toml

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install linting requirements
         run: |
           python -m pip install --upgrade pip
-          pip install --group lint -e .
+          pip install --group lint --group pytest -e .
 
       - name: Run mypy
         run: mypy "." --install-types --non-interactive --config-file pyproject.toml

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -32,7 +32,7 @@ jobs:
           pip install --group lint --group pytest -e .
 
       - name: Run mypy
-        run: mypy "." --install-types --non-interactive --config-file pyproject.toml
+        run: mypy "." --config-file pyproject.toml
 
       - name: Run prek
         uses: j178/prek-action@v2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,5 +18,18 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
+      - name: Setup python
+        id: setup_python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+
+      - name: Install requirements
+        run: pip install --group dev -e .
+
+      - name: Run mypy
+        run: mypy "." --install-types --non-interactive --config-file pyproject.toml
+
       - name: Run prek
         uses: j178/prek-action@v2

--- a/.github/workflows/post_coverage_to_pr.yml
+++ b/.github/workflows/post_coverage_to_pr.yml
@@ -1,0 +1,27 @@
+name: Post coverage Comment to PR
+
+on:
+  workflow_run:
+    workflows: ['pytest and coverage']
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  contents: write
+  actions: read
+
+jobs:
+  test:
+    name: Post coverage Comment to PR
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post coverage Comment to PR
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/post_coverage_to_pr.yml
+++ b/.github/workflows/post_coverage_to_pr.yml
@@ -21,7 +21,7 @@ jobs:
       # DO NOT run actions/checkout here, for security reasons
       # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
       - name: Post coverage Comment to PR
-        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2
+        uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/post_coverage_to_pr.yml
+++ b/.github/workflows/post_coverage_to_pr.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
   actions: read
 
 jobs:
@@ -21,7 +20,7 @@ jobs:
       # DO NOT run actions/checkout here, for security reasons
       # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
       - name: Post coverage Comment to PR
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/post_coverage_to_pr.yml
+++ b/.github/workflows/post_coverage_to_pr.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
   actions: read
 
 jobs:

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   pull-request-tests:
     name: pytest and coverage report
-    if: ${{ github.event_name == 'pull_request' && !(contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot') }}
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,7 +40,7 @@ jobs:
 
       - name: 'Generate coverage Comment (and possibly Post to PR)'
         id: coverage_comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINIMUM_GREEN: 90
@@ -84,7 +84,7 @@ jobs:
         run: pytest
 
       - name: Update coverage baseline
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINIMUM_GREEN: 90

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -8,16 +8,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  pull-requests: write
+  contents: write
 
 jobs:
   pull-request-tests:
     name: pytest and coverage report
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
 
     steps:
       - name: Checkout Repository
@@ -40,6 +37,7 @@ jobs:
         run: pytest
 
       - name: 'Generate coverage Comment (and possibly Post to PR)'
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
@@ -48,7 +46,7 @@ jobs:
           MINIMUM_ORANGE: 70
 
       - name: Store PR Comment to be Posted
-        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
@@ -56,37 +54,3 @@ jobs:
           # If you use a different name, update COMMENT_FILENAME accordingly
           path: python-coverage-comment-action.txt
           retention-days: 1
-
-  coverage-baseline:
-    name: pytest coverage baseline
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      - name: Setup Python 3 (with caching)
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-          cache: 'pip'
-          cache-dependency-path: |
-            pyproject.toml
-
-      - name: Install pytest Requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install --group pytest -e .
-
-      - name: Run pytest with coverage (pytest-cov)
-        run: pytest
-
-      - name: Update coverage baseline
-        uses: py-cov-action/python-coverage-comment-action@v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MINIMUM_GREEN: 90
-          MINIMUM_ORANGE: 70

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -59,7 +59,7 @@ jobs:
 
   coverage-baseline:
     name: pytest coverage baseline
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -11,10 +11,12 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  pull-request-tests:
     name: pytest and coverage report
-    if: ${{ !(github.event_name == 'pull_request' && ( contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot' )) }}
+    if: ${{ github.event_name == 'pull_request' && !(contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Repository
@@ -53,3 +55,37 @@ jobs:
           # If you use a different name, update COMMENT_FILENAME accordingly
           path: python-coverage-comment-action.txt
           retention-days: 1
+
+  coverage-baseline:
+    name: pytest coverage baseline
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python 3 (with caching)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install pytest Requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install --group pytest -e .
+
+      - name: Run pytest with coverage (pytest-cov)
+        run: pytest
+
+      - name: Update coverage baseline
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 70

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -1,0 +1,56 @@
+name: pytest and coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  tests:
+    name: pytest and coverage report
+    if: ${{ !(github.event_name == 'pull_request' && ( contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot' )) }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python 3 (with caching)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Install pytest Requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install --group pytest -e .
+
+      - name: Run pytest with coverage (pytest-cov)
+        run: pytest
+
+      - name: 'Generate coverage Comment (and possibly Post to PR)'
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MINIMUM_GREEN: 90
+          MINIMUM_ORANGE: 70
+
+      - name: Store PR Comment to be Posted
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
+          name: python-coverage-comment-action
+          # If you use a different name, update COMMENT_FILENAME accordingly
+          path: python-coverage-comment-action.txt
+          retention-days: 1

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   tests:

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: 'Generate coverage Comment (and possibly Post to PR)'
         id: coverage_comment
-        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2
+        uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINIMUM_GREEN: 90
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Python 3 (with caching)
         uses: actions/setup-python@v6
@@ -85,7 +85,7 @@ jobs:
         run: pytest
 
       - name: Update coverage baseline
-        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2
+        uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINIMUM_GREEN: 90

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -46,7 +46,7 @@ jobs:
           MINIMUM_ORANGE: 70
 
       - name: Store PR Comment to be Posted
-        if: ${{ github.event_name != 'workflow_dispatch' && steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true' }}
+        if: ${{ github.event_name != 'workflow_dispatch' && steps.coverage_comment.outputs.comment_file_written == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Setup Python 3 (with caching)
         uses: actions/setup-python@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ addopts = """
   --durations=10
   -o console_output_style=progress
   --cov=openvpn_otp_auth
+  --cov-fail-under=0
   --cov-report=term-missing
   --cov-report=html
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,9 @@ py-modules = ["openvpn_otp_auth"]
 version = { attr = "openvpn_otp_auth.VERSION" }
 
 [dependency-groups]
-dev = [
-    "coverage",
+lint = [
     "mypy",
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
-    "pytest-timeout",
-    "pytest-xdist",
+    "prek",
     "ruff",
     "types-cffi",
     "types-PyMySQL",
@@ -41,7 +36,17 @@ dev = [
     "types-PyYAML",
     "types-requests",
     "types-setuptools",
-    "prek",
+]
+pytest = [
+    "pytest-asyncio",
+    "pytest-cov",
+    "pytest-timeout",
+    "pytest-xdist",
+    "pytest",
+]
+dev = [
+    { include-group = "lint" },
+    { include-group = "pytest" },
 ]
 
 [tool.codespell]
@@ -50,25 +55,24 @@ quiet-level = 3
 [tool.pytest.ini_options]
 addopts = """
   --quiet
-  --timeout=10
+  --timeout=20
   --durations=10
   -o console_output_style=progress
-  --junitxml=pytest.xml
-  --cov-report=term
-  --cov-report=xml
+  --cov=openvpn_otp_auth
+  --cov-report=term-missing
   --cov-report=html
 """
 testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true
-parallel = true
+source = ["openvpn_otp_auth"]
+relative_files = true
+parallel = false
 
 [tool.coverage.report]
 show_missing = true
-
-[tool.coverage.xml]
-output = "coverage.xml"
 
 [tool.mypy]
 python_version = "3.14"
@@ -83,6 +87,9 @@ warn_unused_configs = true
 line-length = 100
 indent-width = 4
 fix = true
+force-exclude = true
+target-version = "py314"
+required-version = ">=0.15.0"
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ addopts = """
   --durations=10
   -o console_output_style=progress
   --cov=openvpn_otp_auth
-  --cov-fail-under=0
+  --cov-fail-under=20
   --cov-report=term-missing
   --cov-report=html
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ addopts = """
   --durations=10
   -o console_output_style=progress
   --cov=openvpn_otp_auth
-  --cov-fail-under=20
+  --cov-fail-under=30
   --cov-report=term-missing
   --cov-report=html
 """

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -117,8 +117,6 @@ def test_initial_scrv1_auth_accepts_valid_password_and_totp(
 
     assert exc_info.value.code == 0
     assert stored_sessions == [("alice", "OpenVPN Connect", "198.51.100.10")]
-
-
 def test_changetotp_rewrites_existing_totp_file_when_qr_generation_fails(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import contextlib
 import importlib.util
 import logging
@@ -13,6 +14,7 @@ import sys
 from types import ModuleType
 from typing import Any
 
+import pyotp
 import pytest
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "openvpn_otp_auth.py"
@@ -70,6 +72,53 @@ def test_main_uses_parsed_filename_when_debug_precedes_file(
     assert exc_info.value.code == 1
 
 
+def test_initial_scrv1_auth_accepts_valid_password_and_totp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Initial OpenVPN auth should accept valid password and TOTP credentials."""
+    totp_seed = "JBSWY3DPEHPK3PXP"
+    otp = "123456"
+    encoded_password = base64.b64encode(b"correct-password").decode()
+    encoded_otp = base64.b64encode(otp.encode()).decode()
+    credentials = tmp_path / "credentials.txt"
+    credentials.write_text(f"alice\nSCRV1:{encoded_password}:{encoded_otp}\n")
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", str(credentials)])
+    auth = module.OpenVPNOTPAuth(module.args, install=True)
+    password_hash = auth.ph.hash("correct-password")
+    stored_sessions: list[tuple[str, str, str]] = []
+    monkeypatch.delenv("session_state", raising=False)
+    monkeypatch.setenv("IV_GUI_VER", "OpenVPN Connect")
+    monkeypatch.setenv("untrusted_ip", "198.51.100.10")
+    monkeypatch.setattr(
+        auth,
+        "get_user",
+        lambda _username: ("alice", password_hash, totp_seed, "otpauth://totp/alice"),
+    )
+
+    def verify_totp(totp_secret: str, entered_otp: str) -> bool:
+        """Check the expected TOTP inputs from the auth flow."""
+        return (totp_secret, entered_otp) == (totp_seed, otp)
+
+    monkeypatch.setattr(
+        auth,
+        "verify_totp",
+        verify_totp,
+    )
+    monkeypatch.setattr(
+        auth,
+        "store_session",
+        lambda username, vpn_client, current_ip, _created: stored_sessions.append(
+            (username, vpn_client, current_ip)
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth.main()
+
+    assert exc_info.value.code == 0
+    assert stored_sessions == [("alice", "OpenVPN Connect", "198.51.100.10")]
+
+
 def test_changetotp_rewrites_existing_totp_file_when_qr_generation_fails(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -102,7 +151,7 @@ def test_changetotp_rewrites_existing_totp_file_when_qr_generation_fails(
         auth.changetotp()
 
     assert exc_info.value.code == 99
-    with sqlite3.connect(auth.user_db_file) as db:
+    with contextlib.closing(sqlite3.connect(auth.user_db_file)) as db:
         totp_uri = db.execute(
             "SELECT totp_uri FROM users WHERE username = ?",
             ("alice",),
@@ -134,7 +183,7 @@ def test_deluser_removes_legacy_path_traversal_username_without_unlinking_outsid
         auth.deluser()
 
     assert exc_info.value.code == 99
-    with sqlite3.connect(auth.user_db_file) as db:
+    with contextlib.closing(sqlite3.connect(auth.user_db_file)) as db:
         assert (
             db.execute(
                 "SELECT username FROM users WHERE username = ?",
@@ -171,7 +220,7 @@ def test_changetotp_updates_legacy_path_traversal_username_without_writing_outsi
 
     assert exc_info.value.code == 99
     stdout = capsys.readouterr().out
-    with sqlite3.connect(auth.user_db_file) as db:
+    with contextlib.closing(sqlite3.connect(auth.user_db_file)) as db:
         totp_secret, totp_uri = db.execute(
             "SELECT totp_secret, totp_uri FROM users WHERE username = ?",
             ("../outside",),
@@ -180,6 +229,39 @@ def test_changetotp_updates_legacy_path_traversal_username_without_writing_outsi
     assert totp_uri != "old-uri"
     assert outside_file.read_text() == "do not overwrite"
     assert totp_uri in stdout
+
+
+def test_verify_totp_accepts_current_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TOTP verification should accept the current valid one-time password."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    auth = module.OpenVPNOTPAuth(module.args, install=True)
+    totp_seed = pyotp.random_base32()
+
+    assert auth.verify_totp(totp_seed, pyotp.TOTP(totp_seed).now())
+
+
+def test_store_session_persists_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Session storage should write retrievable SQLite session state."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    auth = module.OpenVPNOTPAuth(module.args, install=True)
+    auth.session_db_file = str(tmp_path / "sessions.db")
+    created = module.datetime.datetime(2026, 5, 12, 10, 30, 0)
+
+    auth.store_session("alice", "OpenVPN Connect", "198.51.100.10", created)
+
+    with contextlib.closing(sqlite3.connect(auth.session_db_file)) as verify_db:
+        verify_cursor = verify_db.execute(
+            "SELECT vpn_client, ip_address, verified_on FROM sessions WHERE username = ?",
+            ("alice",),
+        )
+        try:
+            assert verify_cursor.fetchone() == (
+                "OpenVPN Connect",
+                "198.51.100.10",
+                "2026-05-12 10:30:00",
+            )
+        finally:
+            verify_cursor.close()
 
 
 def test_get_db_cursor_creates_schema(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -117,6 +117,8 @@ def test_initial_scrv1_auth_accepts_valid_password_and_totp(
 
     assert exc_info.value.code == 0
     assert stored_sessions == [("alice", "OpenVPN Connect", "198.51.100.10")]
+
+
 def test_changetotp_rewrites_existing_totp_file_when_qr_generation_fails(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -227,39 +229,6 @@ def test_changetotp_updates_legacy_path_traversal_username_without_writing_outsi
     assert totp_uri != "old-uri"
     assert outside_file.read_text() == "do not overwrite"
     assert totp_uri in stdout
-
-
-def test_verify_totp_accepts_current_code(monkeypatch: pytest.MonkeyPatch) -> None:
-    """TOTP verification should accept the current valid one-time password."""
-    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
-    auth = module.OpenVPNOTPAuth(module.args, install=True)
-    totp_seed = pyotp.random_base32()
-
-    assert auth.verify_totp(totp_seed, pyotp.TOTP(totp_seed).now())
-
-
-def test_store_session_persists_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Session storage should write retrievable SQLite session state."""
-    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
-    auth = module.OpenVPNOTPAuth(module.args, install=True)
-    auth.session_db_file = str(tmp_path / "sessions.db")
-    created = module.datetime.datetime(2026, 5, 12, 10, 30, 0)
-
-    auth.store_session("alice", "OpenVPN Connect", "198.51.100.10", created)
-
-    with contextlib.closing(sqlite3.connect(auth.session_db_file)) as verify_db:
-        verify_cursor = verify_db.execute(
-            "SELECT vpn_client, ip_address, verified_on FROM sessions WHERE username = ?",
-            ("alice",),
-        )
-        try:
-            assert verify_cursor.fetchone() == (
-                "OpenVPN Connect",
-                "198.51.100.10",
-                "2026-05-12 10:30:00",
-            )
-        finally:
-            verify_cursor.close()
 
 
 def test_verify_totp_accepts_current_code(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -262,6 +262,39 @@ def test_store_session_persists_session(monkeypatch: pytest.MonkeyPatch, tmp_pat
             verify_cursor.close()
 
 
+def test_verify_totp_accepts_current_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TOTP verification should accept the current valid one-time password."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    auth = module.OpenVPNOTPAuth(module.args, install=True)
+    totp_seed = pyotp.random_base32()
+
+    assert auth.verify_totp(totp_seed, pyotp.TOTP(totp_seed).now())
+
+
+def test_store_session_persists_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Session storage should write retrievable SQLite session state."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    auth = module.OpenVPNOTPAuth(module.args, install=True)
+    auth.session_db_file = str(tmp_path / "sessions.db")
+    created = module.datetime.datetime(2026, 5, 12, 10, 30, 0)
+
+    auth.store_session("alice", "OpenVPN Connect", "198.51.100.10", created)
+
+    with contextlib.closing(sqlite3.connect(auth.session_db_file)) as verify_db:
+        verify_cursor = verify_db.execute(
+            "SELECT vpn_client, ip_address, verified_on FROM sessions WHERE username = ?",
+            ("alice",),
+        )
+        try:
+            assert verify_cursor.fetchone() == (
+                "OpenVPN Connect",
+                "198.51.100.10",
+                "2026-05-12 10:30:00",
+            )
+        finally:
+            verify_cursor.close()
+
+
 def test_get_db_cursor_creates_schema(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Database cursor helper should create missing SQLite files with the schema."""
     module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib.util
 import logging
 from pathlib import Path
@@ -179,3 +180,25 @@ def test_changetotp_updates_legacy_path_traversal_username_without_writing_outsi
     assert totp_uri != "old-uri"
     assert outside_file.read_text() == "do not overwrite"
     assert totp_uri in stdout
+
+
+def test_get_db_cursor_creates_schema(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Database cursor helper should create missing SQLite files with the schema."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+    auth = module.OpenVPNOTPAuth(module.args, install=True)
+    db_path = tmp_path / "users.db"
+    auth.user_db_file = str(db_path)
+
+    db, cursor = auth.get_userdb_cursor()
+    try:
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users'")
+        assert cursor.fetchone() == ("users",)
+    finally:
+        db.close()
+
+    with contextlib.closing(sqlite3.connect(db_path)) as verify_db:
+        verify_cursor = verify_db.execute("SELECT COUNT(*) FROM users")
+        try:
+            assert verify_cursor.fetchone() == (0,)
+        finally:
+            verify_cursor.close()

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -19,7 +19,7 @@ SCRIPT_PATH = Path(__file__).resolve().parents[1] / "openvpn_otp_auth.py"
 
 def load_module(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> ModuleType:
     """Load the script module with a controlled command-line argument list."""
-    module_name = "openvpn_otp_auth_under_test"
+    module_name = "openvpn_otp_auth"
     monkeypatch.setattr(sys, "argv", argv)
     sys.modules.pop(module_name, None)
     spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
@@ -29,6 +29,14 @@ def load_module(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_module_loads_with_controlled_cli_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The script should be importable when provided valid CLI arguments."""
+    module = load_module(monkeypatch, ["openvpn_otp_auth.py", "--install"])
+
+    assert module.VERSION
+    assert module.args.install is True
 
 
 def test_debug_import_handles_unavailable_log_file(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Adds GitHub Actions coverage automation for pytest and PR coverage comments, and extends the lint workflow to install project lint dependencies and run MyPy in CI.

## What Changed

- Added a `pytest and coverage` workflow for pushes to `main`, pull requests, and manual dispatches.
- Added a follow-up workflow that posts stored coverage comments after successful pull request coverage runs.
- Updated the existing linter workflow to set up Python 3.14, install the lint dependency group, and run MyPy before `prek`.
- Split dependency groups in `pyproject.toml` into `lint`, `pytest`, and aggregate `dev` groups for narrower CI installs.
- Updated pytest and coverage configuration to collect coverage for `openvpn_otp_auth` and added minimal smoke coverage for the standalone script import path.
- Added a scoped Ruff test-file ignore for `assert` usage in pytest tests.

## Why

The repository now has CI coverage for both static checks and pytest coverage reporting. The dependency-group split keeps workflow installs focused while preserving a combined local `dev` group.

## Validation

- `./.venv/bin/pytest`
- `./.venv/bin/mypy .`
- `./.venv/bin/prek run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for authentication workflows, session persistence, and database operations to ensure reliability

* **Chores**
  * Enhanced continuous integration pipeline with automated code quality checks using static analysis tools
  * Improved coverage tracking and automated reporting to pull requests for better code health visibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snuffy2/openvpn_otp_auth/pull/19)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->