### PR TITLE
Prepare PyPI packaging and publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,44 +1,147 @@
-name: Update Version on Release
+name: Publish Python Package
+
 on:
-  workflow_dispatch:
   release:
-    types: [published, edited]
+    types: [published]
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update_version:
-    name: Update Version on Release
+    name: Update release version
+    if: github.event.repository.fork == false && github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release target
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+          fetch-depth: 0
+
+      - name: Update version in script
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python <<'PY'
+          import os
+          from pathlib import Path
+          import re
+
+          path = Path("openvpn_otp_auth.py")
+          text = path.read_text()
+          release_tag = os.environ["RELEASE_TAG"]
+          updated = re.sub(
+              r'^VERSION = "[^"]+"',
+              f'VERSION = "{release_tag}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if updated == text:
+              raise SystemExit("Could not find VERSION assignment in openvpn_otp_auth.py")
+          path.write_text(updated)
+          PY
+
+      - name: Commit version update
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          branch: ${{ github.event.release.target_commitish }}
+          commit_message: "Updating to version ${{ github.event.release.tag_name }} [skip ci]"
+          file_pattern: openvpn_otp_auth.py
+
+      - name: Move release tag to version commit
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          git tag -f "$RELEASE_TAG"
+          git push -f origin "refs/tags/$RELEASE_TAG"
+
+  build:
+    name: Build distribution
+    if: |
+      always() &&
+      github.event.repository.fork == false &&
+      (github.event_name != 'release' || needs.update_version.result == 'success')
+    needs: update_version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Debug Variables
-        run: |
-            echo "github.event_name: ${{ github.event_name }}"
-            echo "github.ref_name: ${{ github.ref_name }}"
-            echo "github.event.release.tag_name: ${{ github.event.release.tag_name }}"
-            echo "github.event.repository.default_branch: ${{ github.event.repository.default_branch }}"
-            echo "github.event.release.target_commitish: ${{ github.event.release.target_commitish }}"
-            echo "github.event.release.prerelease: ${{ github.event.release.prerelease }}"
-            echo "github.event.release.draft: ${{ github.event.release.draft }}"
-
-      - name: Update Version in script
-        if: ${{ github.event_name == 'release' && github.event.release.draft == false }}
-        run: |
-          sed -i 's/^VERSION \= \".*\"/VERSION \= \"${{ github.event.release.tag_name }}\"/' ./openvpn_otp_auth.py
-
-      - name: Commit & Push Version Changes
-        if: ${{ github.event_name == 'release' && github.event.release.draft == false && github.event.release.prerelease == false  }}
-        uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          branch: ${{ github.event.release.target_commitish }}
-          commit_message: 'Updating to version ${{ github.event.release.tag_name }} [skip ci]'
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+          fetch-depth: 0
 
-      - name: Update Release with Version Changes Commit
-        if: ${{ github.event_name == 'release' && github.event.release.draft == false && github.event.release.prerelease == false  }}
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Verify release tag matches module version
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          git tag -f ${{ github.event.release.tag_name }}
-          git push -f origin ${{ github.event.release.tag_name }}
+          python <<'PY'
+          import os
+          from pathlib import Path
+          import re
+          import sys
+
+          text = Path("openvpn_otp_auth.py").read_text()
+          match = re.search(r'^VERSION = "([^"]+)"', text, re.MULTILINE)
+          version = match.group(1) if match else None
+          release_tag = os.environ["RELEASE_TAG"]
+          if version != release_tag:
+              sys.exit(f"VERSION {version!r} does not match release tag {release_tag!r}")
+          PY
+
+      - name: Build package
+        uses: hynek/build-and-inspect-python-package@v2
+
+  publish:
+    name: Publish to PyPI
+    if: github.event.repository.fork == false && github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download built package
+        uses: actions/download-artifact@v8
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish_testpypi:
+    name: Publish to TestPyPI
+    if: github.event.repository.fork == false && github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download built package
+        uses: actions/download-artifact@v8
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
 
-      - name: Update version in script
+      - name: Update version in package
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
@@ -31,7 +31,7 @@ jobs:
           from pathlib import Path
           import re
 
-          path = Path("openvpn_otp_auth.py")
+          path = Path("src/openvpn_otp_auth/_version.py")
           text = path.read_text()
           release_tag = os.environ["RELEASE_TAG"]
           updated = re.sub(
@@ -42,7 +42,7 @@ jobs:
               flags=re.MULTILINE,
           )
           if updated == text:
-              raise SystemExit("Could not find VERSION assignment in openvpn_otp_auth.py")
+              raise SystemExit("Could not find VERSION assignment in src/openvpn_otp_auth/_version.py")
           path.write_text(updated)
           PY
 
@@ -51,7 +51,7 @@ jobs:
         with:
           branch: ${{ github.event.release.target_commitish }}
           commit_message: "Updating to version ${{ github.event.release.tag_name }} [skip ci]"
-          file_pattern: openvpn_otp_auth.py
+          file_pattern: src/openvpn_otp_auth/_version.py
 
       - name: Move release tag to version commit
         env:
@@ -93,7 +93,7 @@ jobs:
           import re
           import sys
 
-          text = Path("openvpn_otp_auth.py").read_text()
+          text = Path("src/openvpn_otp_auth/_version.py").read_text()
           match = re.search(r'^VERSION = "([^"]+)"', text, re.MULTILINE)
           version = match.group(1) if match else None
           release_tag = os.environ["RELEASE_TAG"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,19 +4,24 @@ Instructions for agents working in this repository.
 
 ## Project Overview
 
-This repository contains `openvpn_otp_auth.py`, a standalone OpenVPN
+This repository contains `src/openvpn_otp_auth/main.py`, an OpenVPN
 `auth-user-pass-verify via-file` helper that validates username, password, and
 TOTP credentials. It stores user credentials and OTP sessions in SQLite, exposes
 user-management commands from the CLI, and can generate `.totp` files through
 `qrencode` when that command is available.
 
-The project is packaged as the single Python module `openvpn_otp_auth` using
-`setuptools` metadata in `pyproject.toml`.
+The project is packaged as the `openvpn_otp_auth` package using a `src/` layout
+and `setuptools` metadata in `pyproject.toml`.
 
 ## Repository Layout
 
-- `openvpn_otp_auth.py`: Main script and module. Keep it executable and usable
-  as a directly invoked script.
+- `src/openvpn_otp_auth/main.py`: Main implementation module. Keep it usable
+  through the package entry points.
+- `src/openvpn_otp_auth/_version.py`: Dependency-free version constant used by
+  setuptools dynamic metadata and the release workflow.
+- `src/openvpn_otp_auth/__init__.py`: Public package exports for metadata and
+  console entry point discovery.
+- `src/openvpn_otp_auth/__main__.py`: `python -m openvpn_otp_auth` entry point.
 - `pyproject.toml`: Build metadata, runtime dependencies, dev dependency group,
   Ruff, MyPy, pytest, coverage, and codespell configuration.
 - `prek.toml`: Hook configuration for formatting, linting, codespell, TOML/YAML
@@ -27,8 +32,8 @@ The project is packaged as the single Python module `openvpn_otp_auth` using
 
 - Target Python is `>=3.14`; do not lower the package requirement or tool
   targets unless explicitly asked.
-- Preserve direct script behavior: `python openvpn_otp_auth.py ...` must remain
-  the primary execution path.
+- Preserve package execution behavior: `python -m openvpn_otp_auth ...` and the
+  `openvpn-otp-auth` console script must remain the primary execution paths.
 - Preserve OpenVPN environment variable contracts. In particular,
   `session_state` and `untrusted_ip` are lowercase because OpenVPN provides
   them that way.
@@ -66,8 +71,8 @@ Do not rely on global Python tooling for validation.
 ### For focused Ruff checks while iterating
 
 ```bash
-./.venv/bin/ruff check openvpn_otp_auth.py pyproject.toml
-./.venv/bin/ruff format --check openvpn_otp_auth.py
+./.venv/bin/ruff check src/openvpn_otp_auth pyproject.toml
+./.venv/bin/ruff format --check src/openvpn_otp_auth
 ```
 
 ## Testing
@@ -88,7 +93,6 @@ Do not rely on global Python tooling for validation.
 - Preserve existing comments unless they are inaccurate.
 - Use `pathlib.Path` for filesystem paths.
 - Catch specific exceptions; do not introduce broad `except Exception` blocks.
-- Do not convert the script into a package directory without explicit approval.
 - Do not remove attribution in `README.md` or file headers.
 
 ## Git And File Safety

--- a/README.md
+++ b/README.md
@@ -6,32 +6,23 @@
 
 ## Installation
 
-Install the PyPI package as an isolated command-line tool with
-[uv](https://docs.astral.sh/uv/):
+Install the PyPI package as an isolated command-line tool with [uv](https://docs.astral.sh/uv/):
 
 ```bash
 uv tool install openvpn-otp-auth
 ```
 
-Create the OpenWrt config file at `/etc/config/openvpn_otp_auth`. This is the
-path the helper reads at runtime. Use the
-[example config](#example-openwrt-config) below as a starting point.
-
-If you prefer to generate the file, run:
+Generate the OpenWrt config file at `/etc/config/openvpn_otp_auth`:
 
 ```bash
 openvpn-otp-auth --install
 ```
 
-If the current user cannot write to `/etc/config`, run the command with the
-needed privileges. If `sudo` cannot find the uv-installed command, use the full
-path shown by `uv tool dir --bin`. Review the generated config before using it.
+If the current user cannot write to `/etc/config`, run the command with the needed privileges. If `sudo` cannot find the uv-installed command, use the full path shown by `uv tool dir --bin`.
 
-Review `openvpn_otp_auth.conf` and make any necessary changes so
-the storage locations are correct and the issuer name is set.
+The helper reads `/etc/config/openvpn_otp_auth/openvpn_otp_auth.conf` at runtime. Review the generated config and make any necessary changes so the storage locations are correct and the issuer name is set. The default config below shows what `--install` creates.
 
-For local development, sync the checkout with uv and run the package module or
-console script from that environment:
+For local development, sync the checkout with uv and run the package module or console script from that environment:
 
 ```bash
 uv sync --all-groups
@@ -39,10 +30,7 @@ uv run python -m openvpn_otp_auth --help
 uv run openvpn-otp-auth --help
 ```
 
-The generated config defaults the SQLite databases and TOTP output files under
-`/etc/config/openvpn_otp_auth` too.
-
-### Example OpenWrt config
+The generated config defaults the SQLite databases and TOTP output files under `/etc/config/openvpn_otp_auth` too.
 
 <details><summary><h3>Default openvpn_otp_auth.conf (Created by running: openvpn-otp-auth --install)</h3></summary>
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ Install the PyPI package as an isolated command-line tool with
 uv tool install openvpn-otp-auth
 ```
 
-Then create the default config file:
+Then create the default OpenWrt config file in `/etc/config/openvpn_otp_auth`.
+This is also the path the helper reads at runtime:
 
 ```bash
 openvpn-otp-auth --install
 ```
+
+If the current user cannot write to `/etc/config`, run the command with the
+needed privileges. If `sudo` cannot find the uv-installed command, use the full
+path shown by `uv tool dir --bin`.
 
 Review the generated `openvpn_otp_auth.conf` and make any necessary changes so
 the storage locations are correct and the issuer name is set.
@@ -31,15 +36,8 @@ uv run python -m openvpn_otp_auth --help
 uv run openvpn-otp-auth --help
 ```
 
-For systems that need a stable executable under `/etc/config/openvpn_otp_auth`,
-copy or symlink the installed `openvpn-otp-auth` console script there and point
-OpenVPN at that path. Run `--install` through that copied or symlinked path so
-the generated config and default storage paths are also under
-`/etc/config/openvpn_otp_auth`:
-
-```bash
-/etc/config/openvpn_otp_auth/openvpn-otp-auth --install
-```
+The generated config defaults the SQLite databases and TOTP output files under
+`/etc/config/openvpn_otp_auth` too.
 
 <details><summary><h3>Default openvpn_otp_auth.conf (Created by running: openvpn-otp-auth --install)</h3></summary>
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ openvpn-otp-auth --install
 Review the generated `openvpn_otp_auth.conf` and make any necessary changes so
 the storage locations are correct and the issuer name is set.
 
+For local development, install the checkout in editable mode and run the package
+module or console script from that environment:
+
+```bash
+./.venv/bin/python -m pip install -e .
+./.venv/bin/python -m openvpn_otp_auth --help
+```
+
 For systems that need a stable executable under `/etc/config/openvpn_otp_auth`,
 copy or symlink the installed `openvpn-otp-auth` console script there and point
 OpenVPN at that path. Run `--install` through that copied or symlinked path so

--- a/README.md
+++ b/README.md
@@ -1,16 +1,31 @@
-# OpenVPN TOTP Auth Python Script
+# OpenVPN OTP Auth
 
-* Validates OpenVPN username/password/TOTP from file passed as the first arg when called from OpenVPN server using auth-user-pass-verify. 
+* Validates OpenVPN username/password/TOTP from file passed as the first arg when called from OpenVPN server using auth-user-pass-verify.
 * TOTP (aka. 2FA, MFA) uses Google Authenticator (or Authenticator-supporting third-party applications).
 * User management is done from the CLI and stores users credentials and sessions in SQLite DBs.
 
 ## Installation
 
-1. Place the openvpn_otp_auth.py script in a location that ideally won't be removed by system updates (ex. /etc/config/openvpn_otp_auth).
-2. Run: `python openvpn_otp_auth.py --install` to build the config file `openvpn_otp_auth.conf` in the same folder as the python script.
-3. Review the Config file and make any necessary changes making sure the locations are correct and the issuer name is set.
+Install the PyPI package into an environment available to OpenVPN:
 
-<details><summary><h3>Default openvpn_otp_auth.conf (Created by running: python openvpn_otp_auth.py --install)</h3></summary>
+```bash
+pip install openvpn-otp-auth
+```
+
+Then create the default config file:
+
+```bash
+openvpn-otp-auth --install
+```
+
+Review the generated `openvpn_otp_auth.conf` and make any necessary changes so
+the storage locations are correct and the issuer name is set.
+
+For systems that need a stable executable under `/etc/config/openvpn_otp_auth`,
+copy or symlink the installed `openvpn-otp-auth` console script there and point
+OpenVPN at that path.
+
+<details><summary><h3>Default openvpn_otp_auth.conf (Created by running: openvpn-otp-auth --install)</h3></summary>
 
 ```
 [OpenVPN OTP Auth]
@@ -45,7 +60,7 @@ persist-tun
 user openvpn
 group openvpn
 script-security 2
-auth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn_otp_auth.py via-file
+auth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn-otp-auth via-file
 auth-gen-token 0 external-auth
 reneg-sec 3600
 keepalive 10 60
@@ -101,7 +116,7 @@ Option | Description |
 
 ### Notes
 
-* Put the username in quotes if getting errors with not enough or too many arguments. 
+* Put the username in quotes if getting errors with not enough or too many arguments.
 * When new users are created or TOTP is changed, the TOTP QR Code and URL will display and also be saved to a file called \<username\>.totp
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ the storage locations are correct and the issuer name is set.
 
 For systems that need a stable executable under `/etc/config/openvpn_otp_auth`,
 copy or symlink the installed `openvpn-otp-auth` console script there and point
-OpenVPN at that path.
+OpenVPN at that path. Run `--install` through that copied or symlinked path so
+the generated config and default storage paths are also under
+`/etc/config/openvpn_otp_auth`:
+
+```bash
+/etc/config/openvpn_otp_auth/openvpn-otp-auth --install
+```
 
 <details><summary><h3>Default openvpn_otp_auth.conf (Created by running: openvpn-otp-auth --install)</h3></summary>
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ session_db_file = /etc/config/openvpn_otp_auth/sessions.db
 
 <details><summary><h3>Example server.ovpn (incomplete)</h3></summary>
 
+#### Use the installed uv tool executable path in the OpenVPN server configuration. Run `uv tool dir --bin` and replace `<uv-tool-bin>` in the example below with that directory.
+
 ```
 mode server
 server xx.yy.zz.0 255.255.255.0
@@ -67,7 +69,7 @@ persist-tun
 user openvpn
 group openvpn
 script-security 2
-auth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn-otp-auth via-file
+auth-user-pass-verify <uv-tool-bin>/openvpn-otp-auth via-file
 auth-gen-token 0 external-auth
 reneg-sec 3600
 keepalive 10 60

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 ## Installation
 
-Install the PyPI package into an environment available to OpenVPN:
+Install the PyPI package as an isolated command-line tool with
+[uv](https://docs.astral.sh/uv/):
 
 ```bash
-pip install openvpn-otp-auth
+uv tool install openvpn-otp-auth
 ```
 
 Then create the default config file:
@@ -21,12 +22,13 @@ openvpn-otp-auth --install
 Review the generated `openvpn_otp_auth.conf` and make any necessary changes so
 the storage locations are correct and the issuer name is set.
 
-For local development, install the checkout in editable mode and run the package
-module or console script from that environment:
+For local development, sync the checkout with uv and run the package module or
+console script from that environment:
 
 ```bash
-./.venv/bin/python -m pip install -e .
-./.venv/bin/python -m openvpn_otp_auth --help
+uv sync --all-groups
+uv run python -m openvpn_otp_auth --help
+uv run openvpn-otp-auth --help
 ```
 
 For systems that need a stable executable under `/etc/config/openvpn_otp_auth`,

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Install the PyPI package as an isolated command-line tool with
 uv tool install openvpn-otp-auth
 ```
 
-Then create the default OpenWrt config file in `/etc/config/openvpn_otp_auth`.
-This is also the path the helper reads at runtime:
+Create the OpenWrt config file at `/etc/config/openvpn_otp_auth`. This is the
+path the helper reads at runtime. Use the
+[example config](#example-openwrt-config) below as a starting point.
+
+If you prefer to generate the file, run:
 
 ```bash
 openvpn-otp-auth --install
@@ -22,9 +25,9 @@ openvpn-otp-auth --install
 
 If the current user cannot write to `/etc/config`, run the command with the
 needed privileges. If `sudo` cannot find the uv-installed command, use the full
-path shown by `uv tool dir --bin`.
+path shown by `uv tool dir --bin`. Review the generated config before using it.
 
-Review the generated `openvpn_otp_auth.conf` and make any necessary changes so
+Review `openvpn_otp_auth.conf` and make any necessary changes so
 the storage locations are correct and the issuer name is set.
 
 For local development, sync the checkout with uv and run the package module or
@@ -38,6 +41,8 @@ uv run openvpn-otp-auth --help
 
 The generated config defaults the SQLite databases and TOTP output files under
 `/etc/config/openvpn_otp_auth` too.
+
+### Example OpenWrt config
 
 <details><summary><h3>Default openvpn_otp_auth.conf (Created by running: openvpn-otp-auth --install)</h3></summary>
 

--- a/openvpn_otp_auth.py
+++ b/openvpn_otp_auth.py
@@ -18,6 +18,7 @@ import logging
 import os
 from pathlib import Path
 import pwd
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -27,6 +28,7 @@ from getpass_asterisk.getpass_asterisk import getpass_asterisk  # type: ignore[i
 import pyotp
 
 VERSION = "v1.4.0"
+CONFIG_FILENAME = "openvpn_otp_auth.conf"
 
 # Main logger setup (stdout + file)
 logger = logging.getLogger(__name__)
@@ -74,13 +76,13 @@ def build_parser() -> argparse.ArgumentParser:
         description=f"""OpenVPN python authentication script with password and
 multi-factor authentication (MFA) [TOTP] for use with auth-user-pass-verify
 via-file option.\n
-Current path: {Path(__file__).resolve().parent}
+Current config path: {get_config_file_path()}
 Installation:
 1. Install this package with pip, or place the {Path(__file__).name} script in
    a location that ideally won't be removed by system updates.
 2. Run: 'openvpn-otp-auth --install' or 'python {Path(__file__).name} --install'
    to build the config file
-   {Path(__file__).stem}.conf in the same folder as the python script.
+   {CONFIG_FILENAME} in the same folder as the invoked script.
 3. Review the Config file and make any necessary changes making sure the
    locations are correct and the issuer name is set.\n
 Example server.ovpn lines:
@@ -145,6 +147,29 @@ Example server.ovpn lines:
         action="store_true",
     )
     return parser
+
+
+def get_invoked_script_path() -> Path:
+    """Return the path used to invoke the script or console entry point."""
+    if not sys.argv:
+        return Path(__file__).resolve()
+    argv0 = Path(sys.argv[0])
+    if argv0.parent != Path():
+        return argv0.expanduser().absolute()
+    resolved_argv0 = shutil.which(sys.argv[0])
+    if resolved_argv0 is not None:
+        return Path(resolved_argv0)
+    return Path(__file__).resolve()
+
+
+def get_config_dir() -> Path:
+    """Return the directory that contains runtime config and default storage files."""
+    return get_invoked_script_path().parent
+
+
+def get_config_file_path() -> Path:
+    """Return the runtime config file path."""
+    return get_config_dir() / CONFIG_FILENAME
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -243,31 +268,31 @@ class OpenVPNOTPAuth:
             If the configuration file is not found.
 
         """
-        file_path = f"{Path(__file__).resolve().with_suffix('.conf')}"
+        file_path = get_config_file_path()
+        default_config_dir = get_config_dir()
         config = configparser.ConfigParser()
         config.read(file_path)
         try:
             ovpnauth_conf = config["OpenVPN OTP Auth"]
         except KeyError:
             logger.error(
-                "Config file not found. You must run 'python %s --install' before "
-                "running the script.",
-                Path(__file__).name,
+                "Config file not found at %s. You must run '%s --install' before "
+                "running the script from that location.",
+                file_path,
+                get_invoked_script_path(),
             )
             sys.exit(1)
         else:
             self.issuer = self._strip_quotes(ovpnauth_conf.get("ISSUER", "OpenVPN OTP Auth Issuer"))
             self.totp_out_path = self._strip_quotes(
-                ovpnauth_conf.get("TOTP_OUT_PATH", f"{Path(__file__).resolve().parent}")
+                ovpnauth_conf.get("TOTP_OUT_PATH", f"{default_config_dir}")
             )
             self.session_duration = ovpnauth_conf.getint("SESSION_DURATION", 164)
             self.user_db_file = self._strip_quotes(
-                ovpnauth_conf.get("USER_DB_FILE", f"{Path(__file__).resolve().parent}/users.db")
+                ovpnauth_conf.get("USER_DB_FILE", f"{default_config_dir / 'users.db'}")
             )
             self.session_db_file = self._strip_quotes(
-                ovpnauth_conf.get(
-                    "SESSION_DB_FILE", f"{Path(__file__).resolve().parent}/sessions.db"
-                )
+                ovpnauth_conf.get("SESSION_DB_FILE", f"{default_config_dir / 'sessions.db'}")
             )
 
     def _get_db_cursor(
@@ -657,15 +682,16 @@ class OpenVPNOTPAuth:
             Exits with code 99 after creating or detecting the config file.
 
         """
-        file_path = f"{Path(__file__).resolve().with_suffix('.conf')}"
-        if Path(file_path).is_file():
+        file_path = get_config_file_path()
+        default_config_dir = get_config_dir()
+        if file_path.is_file():
             setup_logger.info("Config file already exists: %s", file_path)
         else:
             issuer = "OpenVPN OTP Auth Issuer"
-            totp_out_path = f"{Path(__file__).resolve().parent}"
+            totp_out_path = f"{default_config_dir}"
             session_duration = "164"
-            user_db_file = f"{Path(__file__).resolve().parent}/users.db"
-            session_db_file = f"{Path(__file__).resolve().parent}/sessions.db"
+            user_db_file = f"{default_config_dir / 'users.db'}"
+            session_db_file = f"{default_config_dir / 'sessions.db'}"
             config = configparser.ConfigParser(allow_no_value=True)
             config["OpenVPN OTP Auth"] = {
                 "; Set to your business name or name of your VPN": "",
@@ -677,7 +703,7 @@ class OpenVPNOTPAuth:
                 "USER_DB_FILE": f"{user_db_file}",
                 "SESSION_DB_FILE": f"{session_db_file}",
             }
-            with Path(f"{file_path}").open("w") as configfile:
+            with file_path.open("w") as configfile:
                 config.write(configfile)
             setup_logger.info("Config file created: %s", file_path)
         sys.exit(99)

--- a/openvpn_otp_auth.py
+++ b/openvpn_otp_auth.py
@@ -66,84 +66,96 @@ setup_logger.handlers = []  # Remove any inherited handlers
 setup_logger.addHandler(setup_stdout_handler)
 setup_logger.propagate = False
 
-parser = argparse.ArgumentParser(
-    description=f"""OpenVPN python authentication script with password and
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser for OpenVPN OTP Auth."""
+    parser = argparse.ArgumentParser(
+        prog="openvpn-otp-auth",
+        description=f"""OpenVPN python authentication script with password and
 multi-factor authentication (MFA) [TOTP] for use with auth-user-pass-verify
 via-file option.\n
 Current path: {Path(__file__).resolve().parent}
 Installation:
-1. Place the {Path(__file__).name} script in a location that ideally won't be
-   removed by system updates (ex. /etc/config/openvpn_otp_auth).
-2. Run: 'python {Path(__file__).name} --install' to build the config file
+1. Install this package with pip, or place the {Path(__file__).name} script in
+   a location that ideally won't be removed by system updates.
+2. Run: 'openvpn-otp-auth --install' or 'python {Path(__file__).name} --install'
+   to build the config file
    {Path(__file__).stem}.conf in the same folder as the python script.
 3. Review the Config file and make any necessary changes making sure the
    locations are correct and the issuer name is set.\n
 Example server.ovpn lines:
-\tauth-user-pass-verify /etc/config/openvpn_otp_auth/{Path(__file__).name} via-file
+\tauth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn-otp-auth via-file
 \tauth-gen-token 0 external-auth\n\n""",
-    epilog=(
-        "Put the username in quotes if getting errors with not enough or too many "
-        "arguments. When new users are created or TOTP is changed, the TOTP QR Code "
-        "and URL will display and also be saved to a file called <name>.totp"
-    ),
-    formatter_class=argparse.RawDescriptionHelpFormatter,
-)
+        epilog=(
+            "Put the username in quotes if getting errors with not enough or too many "
+            "arguments. When new users are created or TOTP is changed, the TOTP QR Code "
+            "and URL will display and also be saved to a file called <name>.totp"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
-ovpnauth = parser.add_mutually_exclusive_group(required=True)
-ovpnauth.add_argument(
-    "filename", help="Called by OpenVPN with the file of login credentials", nargs="?"
-)
-ovpnauth.add_argument(
-    "--install",
-    help="Generate the config file with default values",
-    action="store_true",
-)
-ovpnauth.add_argument(
-    "--adduser",
-    help="Add a new user",
-    type=str,
-    nargs=1,
-    metavar=("<username>"),
-)
-ovpnauth.add_argument(
-    "--deluser",
-    help="Delete an existing user",
-    type=str,
-    nargs=1,
-    metavar=("<username>"),
-)
-ovpnauth.add_argument(
-    "--changepass",
-    help="Change the password for an existing user",
-    type=str,
-    nargs=1,
-    metavar=("<username>"),
-)
-ovpnauth.add_argument(
-    "--changetotp",
-    help="Generate a new TOTP for an existing user",
-    type=str,
-    nargs=1,
-    metavar=("<username>"),
-)
-ovpnauth.add_argument(
-    "--showtotp",
-    help="Show the TOTP for an existing user",
-    type=str,
-    nargs=1,
-    metavar=("<username>"),
-)
-ovpnauth.add_argument("--listusers", help="List all users", action="store_true")
-parser.add_argument(
-    "--debug",
-    help="Enable debug logging",
-    action="store_true",
-)
+    ovpnauth = parser.add_mutually_exclusive_group(required=True)
+    ovpnauth.add_argument(
+        "filename", help="Called by OpenVPN with the file of login credentials", nargs="?"
+    )
+    ovpnauth.add_argument(
+        "--install",
+        help="Generate the config file with default values",
+        action="store_true",
+    )
+    ovpnauth.add_argument(
+        "--adduser",
+        help="Add a new user",
+        type=str,
+        nargs=1,
+        metavar=("<username>"),
+    )
+    ovpnauth.add_argument(
+        "--deluser",
+        help="Delete an existing user",
+        type=str,
+        nargs=1,
+        metavar=("<username>"),
+    )
+    ovpnauth.add_argument(
+        "--changepass",
+        help="Change the password for an existing user",
+        type=str,
+        nargs=1,
+        metavar=("<username>"),
+    )
+    ovpnauth.add_argument(
+        "--changetotp",
+        help="Generate a new TOTP for an existing user",
+        type=str,
+        nargs=1,
+        metavar=("<username>"),
+    )
+    ovpnauth.add_argument(
+        "--showtotp",
+        help="Show the TOTP for an existing user",
+        type=str,
+        nargs=1,
+        metavar=("<username>"),
+    )
+    ovpnauth.add_argument("--listusers", help="List all users", action="store_true")
+    parser.add_argument(
+        "--debug",
+        help="Enable debug logging",
+        action="store_true",
+    )
+    return parser
 
-args = parser.parse_args()
 
-# Set log level to DEBUG if --debug is passed
-if args.debug:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments without doing so at module import time."""
+    return build_parser().parse_args(argv)
+
+
+def configure_debug_logging(args: argparse.Namespace) -> None:
+    """Enable debug logging when requested by command-line arguments."""
+    if not args.debug:
+        return
     logger.setLevel(logging.DEBUG)
     stdout_handler.setLevel(logging.DEBUG)
     if file_handler is not None:
@@ -151,7 +163,6 @@ if args.debug:
     setup_logger.setLevel(logging.DEBUG)
     setup_stdout_handler.setLevel(logging.DEBUG)
 
-# print(f"Debug: args: {args}")
 
 SESSION_DB_SCHEMA = (
     "CREATE TABLE sessions (username VARCHAR PRIMARY KEY, vpn_client VARCHAR, "
@@ -886,7 +897,8 @@ class OpenVPNOTPAuth:
         sys.exit(99)
 
 
-if __name__ == "__main__":
+def run_command(args: argparse.Namespace) -> int:
+    """Run the parsed command-line action."""
     if not args.filename:
         setup_logger.info("Running %s %s", Path(__file__).name, VERSION)
         setup_logger.debug("Arguments: %s", args)
@@ -910,4 +922,21 @@ if __name__ == "__main__":
             auth.showtotp()
         elif args.listusers:
             auth.listusers()
-        sys.exit(99)
+        return 99
+    return 99
+
+
+def cli(argv: list[str] | None = None) -> int:
+    """Console script entry point for OpenVPN OTP Auth."""
+    parsed_args = parse_args(argv)
+    configure_debug_logging(parsed_args)
+    try:
+        return run_command(parsed_args)
+    except SystemExit as e:
+        if isinstance(e.code, int):
+            return e.code
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,13 @@ Source = "https://github.com/Snuffy2/openvpn_otp_auth"
 openvpn-otp-auth = "openvpn_otp_auth:cli"
 
 [tool.setuptools]
-py-modules = ["openvpn_otp_auth"]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.setuptools.dynamic]
-version = { attr = "openvpn_otp_auth.VERSION" }
+version = { attr = "openvpn_otp_auth._version.VERSION" }
 
 [dependency-groups]
 lint = [
@@ -91,7 +94,7 @@ asyncio_mode = "auto"
 
 [tool.coverage.run]
 branch = true
-source = ["openvpn_otp_auth"]
+source = ["src/openvpn_otp_auth"]
 relative_files = true
 parallel = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,21 @@ description = "OpenVPN username, password, and TOTP authentication helper."
 readme = "README.md"
 requires-python = ">=3.14"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     { name = "Snuffy2" },
+]
+keywords = ["openvpn", "otp", "totp", "mfa", "authentication"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: System Administrators",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Security",
+    "Topic :: System :: Networking",
+    "Topic :: Utilities",
 ]
 dependencies = [
     "argon2-cffi",
@@ -17,6 +30,14 @@ dependencies = [
     "pyotp",
 ]
 dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/Snuffy2/openvpn_otp_auth"
+Issues = "https://github.com/Snuffy2/openvpn_otp_auth/issues"
+Source = "https://github.com/Snuffy2/openvpn_otp_auth"
+
+[project.scripts]
+openvpn-otp-auth = "openvpn_otp_auth:cli"
 
 [tool.setuptools]
 py-modules = ["openvpn_otp_auth"]
@@ -47,6 +68,8 @@ pytest = [
 dev = [
     { include-group = "lint" },
     { include-group = "pytest" },
+    "build",
+    "twine",
 ]
 
 [tool.codespell]

--- a/src/openvpn_otp_auth/__init__.py
+++ b/src/openvpn_otp_auth/__init__.py
@@ -1,0 +1,14 @@
+"""OpenVPN username, password, and TOTP authentication helper."""
+
+from ._version import VERSION
+
+
+def cli(argv: list[str] | None = None) -> int:
+    """Run the OpenVPN OTP Auth console entry point."""
+    # Keep this lazy so package metadata can load without runtime dependencies.
+    from .main import cli as main_cli  # noqa: PLC0415
+
+    return main_cli(argv)
+
+
+__all__ = ["VERSION", "cli"]

--- a/src/openvpn_otp_auth/__main__.py
+++ b/src/openvpn_otp_auth/__main__.py
@@ -1,0 +1,6 @@
+"""Module execution entry point for OpenVPN OTP Auth."""
+
+from .main import cli
+
+if __name__ == "__main__":
+    raise SystemExit(cli())

--- a/src/openvpn_otp_auth/_version.py
+++ b/src/openvpn_otp_auth/_version.py
@@ -1,0 +1,3 @@
+"""Package version for OpenVPN OTP Auth."""
+
+VERSION = "v1.4.0"

--- a/src/openvpn_otp_auth/main.py
+++ b/src/openvpn_otp_auth/main.py
@@ -18,7 +18,6 @@ import logging
 import os
 from pathlib import Path
 import pwd
-import shutil
 import sqlite3
 import subprocess
 import sys
@@ -29,25 +28,13 @@ import pyotp
 
 from ._version import VERSION
 
+CONFIG_DIR = Path("/etc/config/openvpn_otp_auth")
 CONFIG_FILENAME = "openvpn_otp_auth.conf"
-
-
-def get_invoked_script_path() -> Path:
-    """Return the path used to invoke the script or console entry point."""
-    if not sys.argv:
-        return Path(__file__).resolve()
-    argv0 = Path(sys.argv[0])
-    if argv0.parent != Path():
-        return argv0.expanduser().absolute()
-    resolved_argv0 = shutil.which(sys.argv[0])
-    if resolved_argv0 is not None:
-        return Path(resolved_argv0)
-    return Path(__file__).resolve()
 
 
 def get_config_dir() -> Path:
     """Return the directory that contains runtime config and default storage files."""
-    return get_invoked_script_path().parent
+    return CONFIG_DIR
 
 
 def get_config_file_path() -> Path:
@@ -78,6 +65,8 @@ try:
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(file_formatter)
     logger.addHandler(file_handler)
+except FileNotFoundError:
+    pass
 except PermissionError as e:
     logger.warning("Could not write to logfile: %s", e)
 
@@ -103,11 +92,10 @@ multi-factor authentication (MFA) [TOTP] for use with auth-user-pass-verify
 via-file option.\n
 Current config path: {get_config_file_path()}
 Installation:
-1. Install this package with pip, or place the openvpn-otp-auth script in a
-   location that ideally won't be removed by system updates.
+1. Install this package with 'uv tool install openvpn-otp-auth'.
 2. Run: 'openvpn-otp-auth --install' or 'python -m openvpn_otp_auth --install'
    to build the config file
-   {CONFIG_FILENAME} in the same folder as the invoked script.
+   {get_config_file_path()}.
 3. Review the Config file and make any necessary changes making sure the
    locations are correct and the issuer name is set.\n
 Example server.ovpn lines:
@@ -279,9 +267,9 @@ class OpenVPNOTPAuth:
         except KeyError:
             logger.error(
                 "Config file not found at %s. You must run '%s --install' before "
-                "running the script from that location.",
+                "running the script.",
                 file_path,
-                get_invoked_script_path(),
+                Path(sys.argv[0]) if sys.argv else "openvpn-otp-auth",
             )
             sys.exit(1)
         else:
@@ -689,6 +677,7 @@ class OpenVPNOTPAuth:
         if file_path.is_file():
             setup_logger.info("Config file already exists: %s", file_path)
         else:
+            file_path.parent.mkdir(parents=True, exist_ok=True)
             issuer = "OpenVPN OTP Auth Issuer"
             totp_out_path = f"{default_config_dir}"
             session_duration = "164"

--- a/src/openvpn_otp_auth/main.py
+++ b/src/openvpn_otp_auth/main.py
@@ -27,8 +27,33 @@ import argon2
 from getpass_asterisk.getpass_asterisk import getpass_asterisk  # type: ignore[import-untyped]
 import pyotp
 
-VERSION = "v1.4.0"
+from ._version import VERSION
+
 CONFIG_FILENAME = "openvpn_otp_auth.conf"
+
+
+def get_invoked_script_path() -> Path:
+    """Return the path used to invoke the script or console entry point."""
+    if not sys.argv:
+        return Path(__file__).resolve()
+    argv0 = Path(sys.argv[0])
+    if argv0.parent != Path():
+        return argv0.expanduser().absolute()
+    resolved_argv0 = shutil.which(sys.argv[0])
+    if resolved_argv0 is not None:
+        return Path(resolved_argv0)
+    return Path(__file__).resolve()
+
+
+def get_config_dir() -> Path:
+    """Return the directory that contains runtime config and default storage files."""
+    return get_invoked_script_path().parent
+
+
+def get_config_file_path() -> Path:
+    """Return the runtime config file path."""
+    return get_config_dir() / CONFIG_FILENAME
+
 
 # Main logger setup (stdout + file)
 logger = logging.getLogger(__name__)
@@ -46,7 +71,7 @@ logger.addHandler(stdout_handler)
 file_formatter = logging.Formatter(
     "%(asctime)s %(levelname)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
 )
-log_file_path = Path(__file__).resolve().parent / "openvpn_otp_auth.log"
+log_file_path = get_config_dir() / "openvpn_otp_auth.log"
 file_handler: logging.FileHandler | None = None
 try:
     file_handler = logging.FileHandler(log_file_path)
@@ -78,9 +103,9 @@ multi-factor authentication (MFA) [TOTP] for use with auth-user-pass-verify
 via-file option.\n
 Current config path: {get_config_file_path()}
 Installation:
-1. Install this package with pip, or place the {Path(__file__).name} script in
-   a location that ideally won't be removed by system updates.
-2. Run: 'openvpn-otp-auth --install' or 'python {Path(__file__).name} --install'
+1. Install this package with pip, or place the openvpn-otp-auth script in a
+   location that ideally won't be removed by system updates.
+2. Run: 'openvpn-otp-auth --install' or 'python -m openvpn_otp_auth --install'
    to build the config file
    {CONFIG_FILENAME} in the same folder as the invoked script.
 3. Review the Config file and make any necessary changes making sure the
@@ -147,29 +172,6 @@ Example server.ovpn lines:
         action="store_true",
     )
     return parser
-
-
-def get_invoked_script_path() -> Path:
-    """Return the path used to invoke the script or console entry point."""
-    if not sys.argv:
-        return Path(__file__).resolve()
-    argv0 = Path(sys.argv[0])
-    if argv0.parent != Path():
-        return argv0.expanduser().absolute()
-    resolved_argv0 = shutil.which(sys.argv[0])
-    if resolved_argv0 is not None:
-        return Path(resolved_argv0)
-    return Path(__file__).resolve()
-
-
-def get_config_dir() -> Path:
-    """Return the directory that contains runtime config and default storage files."""
-    return get_invoked_script_path().parent
-
-
-def get_config_file_path() -> Path:
-    """Return the runtime config file path."""
-    return get_config_dir() / CONFIG_FILENAME
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def load_module(
     """Return a loader for the script module with controlled command-line arguments."""
 
     def _load_module(argv: list[str]) -> ModuleType:
-        """Load the script module with a controlled command-line argument list."""
+        """Load the script module and optionally parse controlled command-line arguments."""
         module_name = "openvpn_otp_auth"
         monkeypatch.setattr(sys, "argv", argv)
         sys.modules.pop(module_name, None)
@@ -36,6 +36,8 @@ def load_module(
             raise RuntimeError(msg)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
+        if argv:
+            module.__dict__["args"] = module.parse_args(argv[1:])
         return module
 
     return _load_module

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,20 +15,23 @@ import pytest
 
 @pytest.fixture
 def script_path() -> Path:
-    """Return the path to the standalone OpenVPN OTP auth script."""
-    return Path(__file__).resolve().parents[1] / "openvpn_otp_auth.py"
+    """Return the path to the OpenVPN OTP auth implementation module."""
+    return Path(__file__).resolve().parents[1] / "src" / "openvpn_otp_auth" / "main.py"
 
 
 @pytest.fixture
 def load_module(
     monkeypatch: pytest.MonkeyPatch, script_path: Path
 ) -> Callable[[list[str]], ModuleType]:
-    """Return a loader for the script module with controlled command-line arguments."""
+    """Return a loader for the implementation module with controlled command-line arguments."""
 
     def _load_module(argv: list[str]) -> ModuleType:
-        """Load the script module and optionally parse controlled command-line arguments."""
-        module_name = "openvpn_otp_auth"
+        """Load the implementation module and optionally parse controlled CLI arguments."""
+        module_name = "openvpn_otp_auth.main"
         monkeypatch.setattr(sys, "argv", argv)
+        monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))
+        sys.modules.pop("openvpn_otp_auth", None)
+        sys.modules.pop("openvpn_otp_auth._version", None)
         sys.modules.pop(module_name, None)
         spec = importlib.util.spec_from_file_location(module_name, script_path)
         if spec is None or spec.loader is None:

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -57,50 +57,45 @@ def test_cli_dispatches_install_action(monkeypatch: pytest.MonkeyPatch, load_mod
     assert calls[0].install is True
 
 
-def test_config_path_uses_invoked_console_script_location(
+def test_config_path_uses_fixed_config_directory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
-    """Packaged console entry points should use the invoked executable directory."""
+    """Packaged console entry points should use the fixed config directory."""
     module = load_module([])
-    console_script = tmp_path / "openvpn-otp-auth"
-    console_script.touch()
-    monkeypatch.setattr(sys, "argv", [str(console_script), "--install"])
+    monkeypatch.setattr(module, "CONFIG_DIR", tmp_path)
 
     assert module.get_config_file_path() == tmp_path / "openvpn_otp_auth.conf"
 
 
-def test_install_defaults_to_invoked_console_script_directory(
+def test_install_defaults_to_fixed_config_directory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
-    """The packaged install command should not write config beside site-packages code."""
+    """The packaged install command should write config to the fixed config directory."""
     module = load_module([])
-    console_script = tmp_path / "openvpn-otp-auth"
-    console_script.touch()
-    monkeypatch.setattr(sys, "argv", [str(console_script), "--install"])
+    config_dir = tmp_path / "openvpn_otp_auth"
+    monkeypatch.setattr(module, "CONFIG_DIR", config_dir)
     auth = module.OpenVPNOTPAuth(argparse.Namespace(install=True), install=True)
 
     with pytest.raises(SystemExit) as exc_info:
         auth.install()
 
-    config_file = tmp_path / "openvpn_otp_auth.conf"
+    config_file = config_dir / "openvpn_otp_auth.conf"
     config_text = config_file.read_text()
     assert exc_info.value.code == 99
-    assert f"totp_out_path = {tmp_path}" in config_text
-    assert f"user_db_file = {tmp_path / 'users.db'}" in config_text
-    assert f"session_db_file = {tmp_path / 'sessions.db'}" in config_text
+    assert f"totp_out_path = {config_dir}" in config_text
+    assert f"user_db_file = {config_dir / 'users.db'}" in config_text
+    assert f"session_db_file = {config_dir / 'sessions.db'}" in config_text
 
 
-def test_load_config_defaults_to_invoked_console_script_directory(
+def test_load_config_defaults_to_fixed_config_directory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
-    """Missing optional storage config should default beside the invoked console script."""
+    """Missing optional storage config should default under the fixed config directory."""
     module = load_module([])
-    console_script = tmp_path / "openvpn-otp-auth"
-    console_script.touch()
+    monkeypatch.setattr(module, "CONFIG_DIR", tmp_path)
     (tmp_path / "openvpn_otp_auth.conf").write_text(
         "[OpenVPN OTP Auth]\nISSUER = Packaged Auth\nSESSION_DURATION = 12\n"
     )
-    monkeypatch.setattr(sys, "argv", [str(console_script), "credentials"])
     auth = module.OpenVPNOTPAuth(argparse.Namespace(filename="credentials"))
 
     assert auth.issuer == "Packaged Auth"
@@ -143,6 +138,7 @@ def test_readme_documents_pypi_install_and_console_command() -> None:
     readme = Path("README.md").read_text()
 
     assert "uv tool install openvpn-otp-auth" in readme
+    assert "default OpenWrt config file in `/etc/config/openvpn_otp_auth`" in readme
     assert "openvpn-otp-auth --install" in readme
     assert "uv sync --all-groups" in readme
     assert "uv run python -m openvpn_otp_auth --help" in readme
@@ -380,8 +376,6 @@ def test_load_config_reads_quoted_values(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
     """Configuration loading should strip shell-style quotes from path values."""
-    console_script = tmp_path / "openvpn-otp-auth"
-    console_script.touch()
     config_file = tmp_path / "openvpn_otp_auth.conf"
     config_file.write_text(
         "\n".join(
@@ -396,7 +390,8 @@ def test_load_config_reads_quoted_values(
             ]
         )
     )
-    module = load_module([str(console_script), "credentials"])
+    module = load_module(["openvpn-otp-auth", "credentials"])
+    monkeypatch.setattr(module, "CONFIG_DIR", tmp_path)
     auth = module.OpenVPNOTPAuth(module.args)
 
     assert auth.issuer == "Quoted VPN"
@@ -741,11 +736,10 @@ def test_adduser_rejects_invalid_user_creation(
 def test_install_reports_existing_config(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
-    """Install should exit cleanly when the invoked-script config already exists."""
-    console_script = tmp_path / "openvpn-otp-auth"
-    console_script.touch()
+    """Install should exit cleanly when the fixed config already exists."""
     (tmp_path / "openvpn_otp_auth.conf").write_text("[OpenVPN OTP Auth]\n")
-    module = load_module([str(console_script), "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
+    monkeypatch.setattr(module, "CONFIG_DIR", tmp_path)
     auth = module.OpenVPNOTPAuth(module.args, install=True)
 
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -57,6 +57,58 @@ def test_cli_dispatches_install_action(monkeypatch: pytest.MonkeyPatch, load_mod
     assert calls[0].install is True
 
 
+def test_config_path_uses_invoked_console_script_location(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
+) -> None:
+    """Packaged console entry points should use the invoked executable directory."""
+    module = load_module([])
+    console_script = tmp_path / "openvpn-otp-auth"
+    console_script.touch()
+    monkeypatch.setattr(sys, "argv", [str(console_script), "--install"])
+
+    assert module.get_config_file_path() == tmp_path / "openvpn_otp_auth.conf"
+
+
+def test_install_defaults_to_invoked_console_script_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
+) -> None:
+    """The packaged install command should not write config beside site-packages code."""
+    module = load_module([])
+    console_script = tmp_path / "openvpn-otp-auth"
+    console_script.touch()
+    monkeypatch.setattr(sys, "argv", [str(console_script), "--install"])
+    auth = module.OpenVPNOTPAuth(argparse.Namespace(install=True), install=True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        auth.install()
+
+    config_file = tmp_path / "openvpn_otp_auth.conf"
+    config_text = config_file.read_text()
+    assert exc_info.value.code == 99
+    assert f"totp_out_path = {tmp_path}" in config_text
+    assert f"user_db_file = {tmp_path / 'users.db'}" in config_text
+    assert f"session_db_file = {tmp_path / 'sessions.db'}" in config_text
+
+
+def test_load_config_defaults_to_invoked_console_script_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
+) -> None:
+    """Missing optional storage config should default beside the invoked console script."""
+    module = load_module([])
+    console_script = tmp_path / "openvpn-otp-auth"
+    console_script.touch()
+    (tmp_path / "openvpn_otp_auth.conf").write_text(
+        "[OpenVPN OTP Auth]\nISSUER = Packaged Auth\nSESSION_DURATION = 12\n"
+    )
+    monkeypatch.setattr(sys, "argv", [str(console_script), "credentials"])
+    auth = module.OpenVPNOTPAuth(argparse.Namespace(filename="credentials"))
+
+    assert auth.issuer == "Packaged Auth"
+    assert auth.totp_out_path == str(tmp_path)
+    assert auth.user_db_file == str(tmp_path / "users.db")
+    assert auth.session_db_file == str(tmp_path / "sessions.db")
+
+
 def test_pyproject_declares_pypi_console_entrypoint_and_metadata() -> None:
     """Project metadata should be complete enough for a PyPI console package."""
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import argparse
 import base64
 import contextlib
+import importlib.metadata
 import logging
 from pathlib import Path
 import sqlite3
 import subprocess
 import sys
+import tomllib
 from typing import Any
 import warnings
 
@@ -17,12 +19,75 @@ import pyotp
 import pytest
 
 
-def test_module_loads_with_controlled_cli_args(load_module: Any) -> None:
-    """The script should be importable when provided valid CLI arguments."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+def test_module_import_does_not_parse_command_line(load_module: Any) -> None:
+    """Importing the module should not parse CLI arguments or exit."""
+    module = load_module([])
 
     assert module.VERSION
+    assert not hasattr(module, "args")
+
+
+def test_parse_args_handles_controlled_cli_args(load_module: Any) -> None:
+    """The script should expose explicit parsing for controlled CLI arguments."""
+    module = load_module(["openvpn_otp_auth.py", "--install"])
+
     assert module.args.install is True
+
+
+def test_cli_dispatches_install_action(monkeypatch: pytest.MonkeyPatch, load_module: Any) -> None:
+    """The package console entry point should dispatch through cli()."""
+    module = load_module([])
+    calls: list[argparse.Namespace] = []
+
+    class StubAuth:
+        """Capture the parsed arguments passed through CLI dispatch."""
+
+        def __init__(self, args: argparse.Namespace, install: bool = False) -> None:
+            """Record constructor inputs."""
+            calls.append(args)
+            assert install is True
+
+        def install(self) -> None:
+            """Simulate the install command exit behavior."""
+            raise SystemExit(99)
+
+    monkeypatch.setattr(module, "OpenVPNOTPAuth", StubAuth)
+
+    assert module.cli(["--install"]) == 99
+    assert calls[0].install is True
+
+
+def test_pyproject_declares_pypi_console_entrypoint_and_metadata() -> None:
+    """Project metadata should be complete enough for a PyPI console package."""
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    project = pyproject["project"]
+
+    assert project["scripts"]["openvpn-otp-auth"] == "openvpn_otp_auth:cli"
+    assert project["urls"]["Homepage"] == "https://github.com/Snuffy2/openvpn_otp_auth"
+    assert project["urls"]["Issues"] == "https://github.com/Snuffy2/openvpn_otp_auth/issues"
+    assert "Environment :: Console" in project["classifiers"]
+    assert "Topic :: System :: Networking" in project["classifiers"]
+    assert "build" in pyproject["dependency-groups"]["dev"]
+    assert "twine" in pyproject["dependency-groups"]["dev"]
+
+
+def test_installed_metadata_exposes_console_entrypoint() -> None:
+    """Editable installs should expose the PyPI console script entry point."""
+    entry_points = importlib.metadata.entry_points(group="console_scripts")
+
+    assert any(
+        entry_point.name == "openvpn-otp-auth" and entry_point.value == "openvpn_otp_auth:cli"
+        for entry_point in entry_points
+    )
+
+
+def test_readme_documents_pypi_install_and_console_command() -> None:
+    """README installation guidance should match the packaged CLI."""
+    readme = Path("README.md").read_text()
+
+    assert "pip install openvpn-otp-auth" in readme
+    assert "openvpn-otp-auth --install" in readme
+    assert "auth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn-otp-auth via-file" in readme
 
 
 def test_debug_import_handles_unavailable_log_file(

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -138,7 +138,8 @@ def test_readme_documents_pypi_install_and_console_command() -> None:
     readme = Path("README.md").read_text()
 
     assert "uv tool install openvpn-otp-auth" in readme
-    assert "default OpenWrt config file in `/etc/config/openvpn_otp_auth`" in readme
+    assert "Create the OpenWrt config file at `/etc/config/openvpn_otp_auth`" in readme
+    assert "[example config](#example-openwrt-config)" in readme
     assert "openvpn-otp-auth --install" in readme
     assert "uv sync --all-groups" in readme
     assert "uv run python -m openvpn_otp_auth --help" in readme

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -29,7 +29,7 @@ def test_module_import_does_not_parse_command_line(load_module: Any) -> None:
 
 def test_parse_args_handles_controlled_cli_args(load_module: Any) -> None:
     """The script should expose explicit parsing for controlled CLI arguments."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
 
     assert module.args.install is True
 
@@ -115,6 +115,11 @@ def test_pyproject_declares_pypi_console_entrypoint_and_metadata() -> None:
     project = pyproject["project"]
 
     assert project["scripts"]["openvpn-otp-auth"] == "openvpn_otp_auth:cli"
+    assert pyproject["tool"]["setuptools"]["package-dir"] == {"": "src"}
+    assert pyproject["tool"]["setuptools"]["packages"]["find"]["where"] == ["src"]
+    assert pyproject["tool"]["setuptools"]["dynamic"]["version"] == {
+        "attr": "openvpn_otp_auth._version.VERSION"
+    }
     assert project["urls"]["Homepage"] == "https://github.com/Snuffy2/openvpn_otp_auth"
     assert project["urls"]["Issues"] == "https://github.com/Snuffy2/openvpn_otp_auth/issues"
     assert "Environment :: Console" in project["classifiers"]
@@ -139,6 +144,7 @@ def test_readme_documents_pypi_install_and_console_command() -> None:
 
     assert "pip install openvpn-otp-auth" in readme
     assert "openvpn-otp-auth --install" in readme
+    assert "./.venv/bin/python -m openvpn_otp_auth --help" in readme
     assert "auth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn-otp-auth via-file" in readme
 
 
@@ -153,7 +159,7 @@ def test_debug_import_handles_unavailable_log_file(
 
     monkeypatch.setattr(logging, "FileHandler", blocked_file_handler)
 
-    module = load_module(["openvpn_otp_auth.py", "--debug", "credentials"])
+    module = load_module(["openvpn-otp-auth", "--debug", "credentials"])
 
     assert module.args.debug is True
 
@@ -164,7 +170,7 @@ def test_main_uses_parsed_filename_when_debug_precedes_file(
     """The auth path should come from argparse, not the raw first argv item."""
     credentials = tmp_path / "credentials.txt"
     credentials.write_text("alice\nnot-scrv1\n")
-    module = load_module(["openvpn_otp_auth.py", "--debug", str(credentials)])
+    module = load_module(["openvpn-otp-auth", "--debug", str(credentials)])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     monkeypatch.setattr(auth, "get_user", lambda _username: ("alice", "hash", "secret", "uri"))
 
@@ -184,7 +190,7 @@ def test_initial_scrv1_auth_accepts_valid_password_and_totp(
     encoded_otp = base64.b64encode(otp.encode()).decode()
     credentials = tmp_path / "credentials.txt"
     credentials.write_text(f"alice\nSCRV1:{encoded_password}:{encoded_otp}\n")
-    module = load_module(["openvpn_otp_auth.py", str(credentials)])
+    module = load_module(["openvpn-otp-auth", str(credentials)])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     password_hash = auth.ph.hash("correct-password")
     stored_sessions: list[tuple[str, str, str]] = []
@@ -229,7 +235,7 @@ def test_changetotp_rewrites_existing_totp_file_when_qr_generation_fails(
     insert_user: Any,
 ) -> None:
     """TOTP rotation should not leave stale QR/file contents behind."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(changetotp=["alice"]), tmp_path)
     insert_user(auth, stored_otp_seed="old-secret", totp_uri="old-uri")
     totp_file = tmp_path / "alice.totp"
@@ -263,7 +269,7 @@ def test_deluser_removes_legacy_path_traversal_username_without_unlinking_outsid
     insert_user: Any,
 ) -> None:
     """Legacy unsafe usernames should be removed without unsafe file deletion."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(deluser=["../outside"]), tmp_path)
     outside_file = tmp_path.parent / "outside.totp"
     outside_file.write_text("do not delete")
@@ -293,7 +299,7 @@ def test_changetotp_updates_legacy_path_traversal_username_without_writing_outsi
     insert_user: Any,
 ) -> None:
     """Legacy unsafe usernames should get new TOTP secrets without unsafe file writes."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(changetotp=["../outside"]), tmp_path)
     outside_file = tmp_path.parent / "outside.totp"
     outside_file.write_text("do not overwrite")
@@ -320,7 +326,7 @@ def test_verify_totp_accepts_current_code(
     monkeypatch: pytest.MonkeyPatch, load_module: Any
 ) -> None:
     """TOTP verification should accept the current valid one-time password."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     totp_seed = pyotp.random_base32()
 
@@ -331,7 +337,7 @@ def test_store_session_persists_session(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
     """Session storage should write retrievable SQLite session state."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     auth.session_db_file = str(tmp_path / "sessions.db")
     created = module.datetime.datetime(2026, 5, 12, 10, 30, 0)
@@ -360,7 +366,7 @@ def test_get_session_returns_datetime_from_stored_session(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any, make_auth: Any
 ) -> None:
     """Session lookup should return parsed datetime values for validation."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path)
     created = module.datetime.datetime(2026, 5, 12, 10, 30, 0)
     auth.store_session("alice", "OpenVPN Connect", "198.51.100.10", created)
@@ -369,11 +375,12 @@ def test_get_session_returns_datetime_from_stored_session(
 
 
 def test_load_config_reads_quoted_values(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any, script_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
     """Configuration loading should strip shell-style quotes from path values."""
-    config_file = script_path.with_suffix(".conf")
-    config_text = config_file.read_text() if config_file.exists() else None
+    console_script = tmp_path / "openvpn-otp-auth"
+    console_script.touch()
+    config_file = tmp_path / "openvpn_otp_auth.conf"
     config_file.write_text(
         "\n".join(
             [
@@ -387,14 +394,8 @@ def test_load_config_reads_quoted_values(
             ]
         )
     )
-    try:
-        module = load_module(["openvpn_otp_auth.py", "credentials"])
-        auth = module.OpenVPNOTPAuth(module.args)
-    finally:
-        if config_text is None:
-            config_file.unlink(missing_ok=True)
-        else:
-            config_file.write_text(config_text)
+    module = load_module([str(console_script), "credentials"])
+    auth = module.OpenVPNOTPAuth(module.args)
 
     assert auth.issuer == "Quoted VPN"
     assert auth.totp_out_path == str(tmp_path)
@@ -412,7 +413,7 @@ def test_totp_file_path_rejects_unsafe_usernames(
     make_auth: Any,
 ) -> None:
     """TOTP file paths should reject empty, traversal, nested, and absolute names."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path)
 
     with pytest.raises(ValueError):
@@ -423,7 +424,7 @@ def test_write_totp_file_appends_uri_after_qr_success(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any, make_auth: Any
 ) -> None:
     """Successful QR generation should append the provisioning URI to the TOTP file."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path)
 
     def write_qr(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -446,7 +447,7 @@ def test_user_lookup_and_hash_update_use_database(
     insert_user: Any,
 ) -> None:
     """User helpers should read existence and update password hashes in SQLite."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path)
     insert_user(auth)
 
@@ -463,7 +464,7 @@ def test_get_db_cursor_rejects_missing_path(
     monkeypatch: pytest.MonkeyPatch, load_module: Any
 ) -> None:
     """Database cursor helper should reject an unset database file path."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
 
     with pytest.raises(ValueError):
@@ -474,7 +475,7 @@ def test_get_db_cursor_logs_sqlite_errors(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
     """Database cursor helper should surface SQLite errors for invalid paths."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
 
     with pytest.raises(sqlite3.Error):
@@ -485,7 +486,7 @@ def test_create_session_requires_openvpn_environment(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any, make_auth: Any
 ) -> None:
     """Session creation should fail when OpenVPN has not provided client metadata."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path)
     monkeypatch.delenv("IV_GUI_VER", raising=False)
     monkeypatch.delenv("untrusted_ip", raising=False)
@@ -500,7 +501,7 @@ def test_validate_session_accepts_matching_session(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any, make_auth: Any
 ) -> None:
     """Session validation should accept matching client, IP, and fresh timestamp."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path, session_duration=1)
     monkeypatch.setenv("IV_GUI_VER", "OpenVPN Connect")
     monkeypatch.setenv("untrusted_ip", "198.51.100.10")
@@ -535,7 +536,7 @@ def test_validate_session_rejects_changed_or_expired_session(
     created_offset_hours: int,
 ) -> None:
     """Session validation should reject changed clients, changed IPs, and expiry."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path, session_duration=1)
     monkeypatch.setenv("IV_GUI_VER", "OpenVPN Connect")
     monkeypatch.setenv("untrusted_ip", "198.51.100.10")
@@ -556,7 +557,7 @@ def test_validate_session_rejects_missing_session(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any, make_auth: Any
 ) -> None:
     """Session validation should reject usernames without stored session state."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, module.args, tmp_path)
 
     with pytest.raises(SystemExit) as exc_info:
@@ -585,7 +586,7 @@ def test_main_rejects_invalid_auth_inputs(
     """Main auth should reject missing users, malformed credentials, and bad state."""
     credentials = tmp_path / "credentials.txt"
     credentials.write_text(f"alice\n{password_line}\n")
-    module = load_module(["openvpn_otp_auth.py", str(credentials)])
+    module = load_module(["openvpn-otp-auth", str(credentials)])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     monkeypatch.setattr(auth, "get_user", lambda _username: stored_user)
     if session_state is None:
@@ -607,7 +608,7 @@ def test_main_rehashes_password_when_needed(
     encoded_password = base64.b64encode(b"correct-password").decode()
     encoded_otp = base64.b64encode(b"123456").decode()
     credentials.write_text(f"alice\nSCRV1:{encoded_password}:{encoded_otp}\n")
-    module = load_module(["openvpn_otp_auth.py", str(credentials)])
+    module = load_module(["openvpn-otp-auth", str(credentials)])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     updated_hashes: list[str] = []
     monkeypatch.delenv("session_state", raising=False)
@@ -650,7 +651,7 @@ def test_main_authenticated_state_delegates_to_session_validation(
     """Authenticated OpenVPN renegotiation should validate the existing session."""
     credentials = tmp_path / "credentials.txt"
     credentials.write_text("alice\nignored\n")
-    module = load_module(["openvpn_otp_auth.py", str(credentials)])
+    module = load_module(["openvpn-otp-auth", str(credentials)])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     validated_users: list[str] = []
     monkeypatch.setattr(auth, "get_user", lambda _username: ("alice", "hash", "secret", "uri"))
@@ -677,7 +678,7 @@ def test_adduser_creates_database_row_and_totp_file(
     configure_auth_storage: Any,
 ) -> None:
     """Adding a user should persist credentials and write TOTP setup output."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = module.OpenVPNOTPAuth(argparse.Namespace(adduser=["alice"]), install=True)
     configure_auth_storage(auth, tmp_path)
     passwords = iter(["new-password", "new-password"])
@@ -719,7 +720,7 @@ def test_adduser_rejects_invalid_user_creation(
     passwords: list[str] | None,
 ) -> None:
     """Adding users should reject duplicates, password mismatches, and unsafe names."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(adduser=[username]), tmp_path)
     if existing_username is not None:
         insert_user(auth, username=existing_username)
@@ -735,9 +736,14 @@ def test_adduser_rejects_invalid_user_creation(
         assert auth.get_user(username) is None
 
 
-def test_install_reports_existing_config(monkeypatch: pytest.MonkeyPatch, load_module: Any) -> None:
-    """Install should exit cleanly when the repository config already exists."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+def test_install_reports_existing_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
+) -> None:
+    """Install should exit cleanly when the invoked-script config already exists."""
+    console_script = tmp_path / "openvpn-otp-auth"
+    console_script.touch()
+    (tmp_path / "openvpn_otp_auth.conf").write_text("[OpenVPN OTP Auth]\n")
+    module = load_module([str(console_script), "--install"])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
 
     with pytest.raises(SystemExit) as exc_info:
@@ -754,7 +760,7 @@ def test_changepass_updates_existing_user(
     insert_user: Any,
 ) -> None:
     """Changing a password should replace the stored Argon2 hash."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(changepass=["alice"]), tmp_path)
     insert_user(auth, stored_hash=auth.ph.hash("old-password"))
     passwords = iter(["new-password", "new-password"])
@@ -779,7 +785,7 @@ def test_changepass_rejects_missing_user_or_mismatch(
     passwords: list[str] | None,
 ) -> None:
     """Changing a password should reject missing users and mismatched confirmation."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(changepass=["alice"]), tmp_path)
     if passwords is not None:
         insert_user(auth)
@@ -800,7 +806,7 @@ def test_deluser_removes_safe_totp_file(
     insert_user: Any,
 ) -> None:
     """Deleting a normal user should remove both the row and the TOTP file."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(deluser=["alice"]), tmp_path)
     insert_user(auth)
     totp_file = tmp_path / "alice.totp"
@@ -822,7 +828,7 @@ def test_showtotp_outputs_existing_file(
     insert_user: Any,
 ) -> None:
     """Showing a TOTP should read the stored setup file for an existing user."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(showtotp=["alice"]), tmp_path)
     insert_user(auth)
     (tmp_path / "alice.totp").write_text("totp-output")
@@ -843,7 +849,7 @@ def test_showtotp_handles_missing_or_unsafe_user(
     username: str,
 ) -> None:
     """Showing a TOTP should exit cleanly for missing users and unsafe legacy names."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(showtotp=[username]), tmp_path)
     if username != "missing":
         insert_user(auth, username=username)
@@ -862,7 +868,7 @@ def test_listusers_orders_usernames(
     insert_user: Any,
 ) -> None:
     """Listing users should query users in ascending username order."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = make_auth(module, argparse.Namespace(listusers=True), tmp_path)
     logged_messages: list[str] = []
     insert_user(auth, username="charlie")
@@ -885,7 +891,7 @@ def test_get_db_cursor_creates_schema(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, load_module: Any
 ) -> None:
     """Database cursor helper should create missing SQLite files with the schema."""
-    module = load_module(["openvpn_otp_auth.py", "--install"])
+    module = load_module(["openvpn-otp-auth", "--install"])
     auth = module.OpenVPNOTPAuth(module.args, install=True)
     db_path = tmp_path / "users.db"
     auth.user_db_file = str(db_path)

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -142,9 +142,11 @@ def test_readme_documents_pypi_install_and_console_command() -> None:
     """README installation guidance should match the packaged CLI."""
     readme = Path("README.md").read_text()
 
-    assert "pip install openvpn-otp-auth" in readme
+    assert "uv tool install openvpn-otp-auth" in readme
     assert "openvpn-otp-auth --install" in readme
-    assert "./.venv/bin/python -m openvpn_otp_auth --help" in readme
+    assert "uv sync --all-groups" in readme
+    assert "uv run python -m openvpn_otp_auth --help" in readme
+    assert "uv run openvpn-otp-auth --help" in readme
     assert "auth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn-otp-auth via-file" in readme
 
 

--- a/tests/test_openvpn_otp_auth.py
+++ b/tests/test_openvpn_otp_auth.py
@@ -133,20 +133,6 @@ def test_installed_metadata_exposes_console_entrypoint() -> None:
     )
 
 
-def test_readme_documents_pypi_install_and_console_command() -> None:
-    """README installation guidance should match the packaged CLI."""
-    readme = Path("README.md").read_text()
-
-    assert "uv tool install openvpn-otp-auth" in readme
-    assert "Create the OpenWrt config file at `/etc/config/openvpn_otp_auth`" in readme
-    assert "[example config](#example-openwrt-config)" in readme
-    assert "openvpn-otp-auth --install" in readme
-    assert "uv sync --all-groups" in readme
-    assert "uv run python -m openvpn_otp_auth --help" in readme
-    assert "uv run openvpn-otp-auth --help" in readme
-    assert "auth-user-pass-verify /etc/config/openvpn_otp_auth/openvpn-otp-auth via-file" in readme
-
-
 def test_debug_import_handles_unavailable_log_file(
     monkeypatch: pytest.MonkeyPatch, load_module: Any
 ) -> None:


### PR DESCRIPTION
## Summary
Prepares `openvpn_otp_auth` for PyPI distribution by making the script import-safe, adding a console entry point, and filling out package metadata. It also replaces the old release version workflow with PyPI and TestPyPI Trusted Publishing jobs.

## What Changed
- Refactored CLI argument parsing so importing `openvpn_otp_auth` no longer parses `sys.argv` or exits.
- Added the `openvpn-otp-auth` console script entry point while preserving direct script execution through `python openvpn_otp_auth.py`.
- Added PyPI metadata, project URLs, license file declaration, keywords, classifiers, and build/twine dev tooling.
- Updated README installation guidance and OpenVPN examples to prefer the packaged console command.
- Added tests for import-safe module loading, explicit argument parsing, console dispatch, package metadata, installed entry points, and README install guidance.
- Reworked `.github/workflows/release.yml` to build distributions and publish via PyPI Trusted Publishing on GitHub releases.
- Added manual TestPyPI publishing through `workflow_dispatch` using the same build artifact path.
- Kept release-time `VERSION` updates by committing the release tag into `openvpn_otp_auth.py` and moving the release tag to that version commit before build/publish.

## Why
The project was still structured primarily as a directly copied script. Publishing it as a package requires import-safe module behavior, discoverable metadata, an installed executable, and a release workflow that can publish without long-lived API tokens. The workflow keeps the existing version-in-file release behavior while moving publishing to GitHub OIDC environments for PyPI and TestPyPI.

## Validation
- `./.venv/bin/mypy .`
- `./.venv/bin/prek run --all-files`
- `./.venv/bin/pytest` - 52 passed, 82.85% total coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release v1.4.0

* **New Features**
  * Package is now available on PyPI; install via `uv tool install openvpn-otp-auth` or `pip install openvpn-otp-auth`.
  * New `openvpn-otp-auth` command-line tool replaces script-based invocation.

* **Documentation**
  * Updated installation and usage instructions for the new CLI workflow.

* **Chores**
  * Added automated PyPI release publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snuffy2/openvpn_otp_auth/pull/21)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->