### PR TITLE
Use reusable prek autoupdate workflow

### DIFF
--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -11,3 +11,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write

--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -6,50 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-<<<<<<< migrate-prek-autoupdate
   prek-autoupdate:
     uses: Snuffy2/prek-autoupdate/.github/workflows/prek_autoupdate.yml@v1
     permissions:
       contents: write
       pull-requests: write
       actions: write
-=======
-  update-hooks:
-    name: Update prek Hooks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-
-      - name: Install prek
-        uses: taiki-e/install-action@v2
-        with:
-          tool: prek
-
-      - name: Run prek auto-update
-        id: prek
-        run: |
-          set -euo pipefail
-          body_file="$GITHUB_WORKSPACE/prek-autoupdate-body.md"
-          {
-            echo "Automated update of \`prek\` hooks."
-            echo
-            echo '```text'
-            prek auto-update --cooldown-days 7 2>&1
-            echo '```'
-          } | tee "$body_file"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        id: cpr
-        with:
-          commit-message: 'chore: update prek hooks'
-          title: 'Bump prek Hooks'
-          branch: chore/prek-updates
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          labels: dependencies
-          delete-branch: true
-          body-path: prek-autoupdate-body.md
-          add-paths: |
-            prek.toml
->>>>>>> main

--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -1,49 +1,13 @@
 name: prek Autoupdate
+
 on:
   schedule:
-    - cron: '0 2 * * 1'
+    - cron: '23 8 * * 3'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  update-hooks:
-    name: Update prek Hooks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      - name: Install prek
-        uses: taiki-e/install-action@v2
-        with:
-          tool: prek
-
-      - name: Run prek auto-update
-        id: prek
-        run: |
-          set -euo pipefail
-          body_file="$GITHUB_WORKSPACE/prek-autoupdate-body.md"
-          {
-            echo "Automated update of \`prek\` hooks."
-            echo
-            echo '```text'
-            prek auto-update --cooldown-days 7 2>&1
-            echo '```'
-          } | tee "$body_file"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        id: cpr
-        with:
-          commit-message: 'chore: update prek hooks'
-          title: 'Bump prek Hooks'
-          branch: chore/prek-updates
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          labels: dependencies
-          delete-branch: true
-          body-path: prek-autoupdate-body.md
-          add-paths: |
-            prek.toml
+  prek-autoupdate:
+    uses: Snuffy2/prek-autoupdate/.github/workflows/prek_autoupdate.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary
Migrates the local prek autoupdate workflow to the reusable workflow from `Snuffy2/prek-autoupdate`.

## What Changed
- Replaced the copied `.github/workflows/prek_autoupdate.yml` implementation with a thin reusable workflow caller.
- Kept the scheduled run on a scattered overnight cadence.

## Why
The reusable workflow centralizes prek update behavior in one repository, so this repo no longer needs to carry a copied workflow implementation.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a copied 49-line local prek autoupdate workflow with a thin caller that delegates to the centralized reusable workflow at `Snuffy2/prek-autoupdate/.github/workflows/prek_autoupdate.yml@v1`. The schedule is shifted from Monday at 02:00 UTC to Wednesday at 08:23 UTC.

- The local implementation (checkout, install prek, run auto-update, open PR) is removed entirely, reducing maintenance surface in this repo.
- Permissions are moved from workflow-level to job-level, and an `actions: write` grant is added beyond what the original required — worth confirming this is needed by the upstream workflow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a straightforward delegation to a reusable workflow owned by the same author, and the resulting file is valid YAML with no functional regressions.

The only substantive change besides removing the local implementation is the addition of `actions: write` and a schedule shift. No logic that previously ran locally is lost — it moves upstream. The extra permission is a minor question rather than a current defect.

No files require special attention; the single changed workflow file is clean and parses correctly.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/prek_autoupdate.yml | Replaces a 49-line local prek autoupdate implementation with a thin 14-line caller delegating to Snuffy2/prek-autoupdate@v1; schedule is updated from Monday 02:00 UTC to Wednesday 08:23 UTC, and an actions: write permission is added beyond what the original workflow required. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Update prek\_autoupdate.yml"](https://github.com/snuffy2/openvpn_otp_auth/commit/77760116317d75a1b18c676acf235b492a7880ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41979054)</sub>

<!-- /greptile_comment -->