### PR TITLE
Run prek cleanup daily

### DIFF
--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -2,7 +2,7 @@ name: prek Autoupdate
 
 on:
   schedule:
-    - cron: '23 8 * * 3'
+    - cron: '23 8 * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,3 +12,8 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
+    with:
+      update-day: "3"
+      dispatch-workflows: |
+        linters.yml
+        pytest_coverage.yml


### PR DESCRIPTION
## Summary
Updates the reusable prek autoupdate caller so cleanup can run daily while update checks stay weekly.

## What Changed
- Changes the caller cron to run every day.
- Preserves the previous weekly update day with `update-day`.
- Adds `dispatch-workflows` for existing validation workflows and keeps `actions: write` for that dispatch path.

## Why
The reusable workflow now separates daily cleanup from weekly update checks. This keeps stale update PR and branch cleanup running nightly without opening hook update PRs every day.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the `prek_autoupdate` caller workflow to run daily instead of weekly, while delegating the weekly-update-only guard to the reusable workflow via the new `update-day: "3"` input. The `dispatch-workflows` input is also added so the reusable workflow can trigger `linters.yml` and `pytest_coverage.yml` for validation.

- The cron is changed from `'23 8 * * 3'` (Wednesdays) to `'23 8 * * *'` (every day), and `update-day: "3"` passes the equivalent Wednesday constraint into the reusable workflow so update PRs are still only opened on that day.
- Both workflow filenames in `dispatch-workflows` (`linters.yml`, `pytest_coverage.yml`) exist in the repository, so dispatch calls should resolve correctly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-reasoned cron and input adjustment with no logic errors or missing references.

The cron expression is correct, `update-day: "3"` correctly maps to Wednesday (matching the previous weekly-only schedule), and both workflow filenames listed under `dispatch-workflows` exist in the repository. No permissions are added beyond what was already present.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/prek_autoupdate.yml | Cron changed from weekly (Wednesday) to daily; update-day="3" and dispatch-workflows inputs added to the reusable workflow call to preserve Wednesday-only update behavior while allowing daily cleanup to run. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Run prek cleanup daily"](https://github.com/snuffy2/openvpn_otp_auth/commit/6b07d446c265880ccfcb6aad54b13252f54714a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42070551)</sub>

<!-- /greptile_comment -->